### PR TITLE
Add possibility to set proxy for API requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ OpenSkyStates states = new OpenSkyApi().getStates(0);
 System.out.println("Number of states: " + states.getStates().size());
 ```
 
+### Proxy configuration
+
+To set a proxy for API request set prxy setting after OpenSkyApi initialization.
+
+```
+OpenSkyApi api = new OpenSkyApi();
+api.setProxy(new HttpHost("proxy_adress",proxy_port);
+```
+
 ### Using the API within Android Apps
 
 Build and install the OpenSky API in your local repository as described above.

--- a/java/src/main/java/org/opensky/api/OpenSkyApi.java
+++ b/java/src/main/java/org/opensky/api/OpenSkyApi.java
@@ -33,6 +33,8 @@ public class OpenSkyApi {
 	private static final String API_ROOT = "https://" + HOST + "/api";
 	private static final String STATES_URI = API_ROOT + "/states/all";
 	private static final String MY_STATES_URI = API_ROOT + "/states/own";
+	
+	private static HttpHost proxy;
 
 	private String username;
 	private String password;
@@ -117,7 +119,7 @@ public class OpenSkyApi {
 	private OpenSkyStates getOpenSkyStates(String baseUri, ArrayList<NameValuePair> nvps) throws IOException {
 		try {
 			return statesRh.handleResponse(executor.execute(Request.Get(new URIBuilder(baseUri)
-					.addParameters(nvps).build())).returnResponse());
+					.addParameters(nvps).build()).viaProxy(proxy)).returnResponse());
 		} catch (URISyntaxException e) {
 			// this should not happen
 			e.printStackTrace();
@@ -177,4 +179,14 @@ public class OpenSkyApi {
 		nvps.add(new BasicNameValuePair("time", Integer.toString(time)));
 		return checkRateLimit(0, 900, 0) ? getOpenSkyStates(MY_STATES_URI, nvps) : null;
 	}
+
+	public HttpHost getProxy() {
+		return proxy;
+	}
+
+	public void setProxy(HttpHost proxy) {
+		OpenSkyApi.proxy = proxy;
+	}
+	
+	
 }

--- a/java/src/test/java/TestOpenSkyApi.java
+++ b/java/src/test/java/TestOpenSkyApi.java
@@ -1,3 +1,6 @@
+package test.java;
+
+import org.apache.http.HttpHost;
 import org.junit.Test;
 import org.opensky.api.OpenSkyApi;
 import org.opensky.model.OpenSkyStates;
@@ -16,10 +19,14 @@ public class TestOpenSkyApi {
 	static final String PASSWORD = null;
 	// serials which belong to the given account
 	static final Integer[] SERIALS = null;
+	// Http proxy, leave null if empty
+	static final HttpHost PROXY = null;
 
 	@Test
 	public void testAnonGetStates() throws IOException, InterruptedException {
 		OpenSkyApi api = new OpenSkyApi();
+		// To make request to opensky API through a proxy set it after OpenSkyApi initialisation.
+		// api.setProxy(new HttpHost("proxy_adress",proxy_port);
 		long t0 = System.nanoTime();
 		OpenSkyStates os = api.getStates(0, null);
 		long t1 = System.nanoTime();

--- a/java/src/test/java/TestOpenSkyStatesDeserializer.java
+++ b/java/src/test/java/TestOpenSkyStatesDeserializer.java
@@ -1,3 +1,5 @@
+package test.java;
+
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;


### PR DESCRIPTION
I use OpenSky API at work and i noticed it was impossible to use it through a proxy.
So i add HttpHost attribute for store a proxy host in OpenskyAPI.java, and i use it on Get request on method viaProxy().

I hope this could be usefull for another people.
