### PR TITLE
Fix bug that can prevent fast-polling clients from ever getting data again

### DIFF
--- a/java/src/main/java/org/opensky/api/OpenSkyApi.java
+++ b/java/src/main/java/org/opensky/api/OpenSkyApi.java
@@ -136,8 +136,15 @@ public class OpenSkyApi {
 	private boolean checkRateLimit(REQUEST_TYPE type, long timeDiffAuth, long timeDiffNoAuth) {
 		Long t = lastRequestTime.get(type);
 		long now = System.currentTimeMillis();
-		lastRequestTime.put(type, now);
-		return (t == null || (authenticated && now - t > timeDiffAuth) || (!authenticated && now - t > timeDiffNoAuth));
+		boolean mayIssueRequest = t == null
+				|| (authenticated && now - t > timeDiffAuth)
+				|| (!authenticated && now - t > timeDiffNoAuth);
+		if (mayIssueRequest) {
+			// Optimistically update the last request time if the client can actually issue a request. If the request
+			// fails, we don't want to immediately retry anyway
+			lastRequestTime.put(type, now);
+		}
+		return mayIssueRequest;
 	}
 
 	/**


### PR DESCRIPTION
Fixes a bug in the Java client where a fast-polling client (i.e. more frequently than the 4900ms/9900ms rate-limiting for anon/authed, respectively) could result in never making a call to the OpenSky API again.

The issue here was that we would always update `lastRequestTime` even if the caller wasn't actually able to issue a call, resulting in never being able to issue a call after the first time.