### PR TITLE
Adding vehicle category to Python API. Fixed unittests.

### DIFF
--- a/python/opensky_api.py
+++ b/python/opensky_api.py
@@ -54,11 +54,12 @@ class StateVector(object):
       |  **squawk** - transponder code aka Squawk. Can be None
       |  **spi** - special purpose indicator
       |  **position_source** - origin of this state's position: 0 = ADS-B, 1 = ASTERIX, 2 = MLAT, 3 = FLARM
+      |  **category** - aircraft category: 0 = No information at all, 1 = No ADS-B Emitter Category Information, 2 = Light (< 15500 lbs), 3 = Small (15500 to 75000 lbs), 4 = Large (75000 to 300000 lbs), 5 = High Vortex Large (aircraft such as B-757), 6 = Heavy (> 300000 lbs), 7 = High Performance (> 5g acceleration and 400 kts), 8 = Rotorcraft, 9 = Glider / sailplane, 10 = Lighter-than-air, 11 = Parachutist / Skydiver, 12 = Ultralight / hang-glider / paraglider, 13 = Reserved, 14 = Unmanned Aerial Vehicle, 15 = Space / Trans-atmospheric vehicle, 16 = Surface Vehicle – Emergency Vehicle, 17 = Surface Vehicle – Service Vehicle, 18 = Point Obstacle (includes tethered balloons), 19 = Cluster Obstacle, 20 = Line Obstacle
     """
     keys = ["icao24", "callsign", "origin_country", "time_position",
             "last_contact", "longitude", "latitude", "baro_altitude", "on_ground",
             "velocity", "true_track", "vertical_rate", "sensors",
-            "geo_altitude", "squawk", "spi", "position_source"]
+            "geo_altitude", "squawk", "spi", "position_source", "category"]
 
     # We are not using namedtuple here as state vectors from the server might be extended; zip() will ignore additional
     #  entries in this case
@@ -160,7 +161,7 @@ class OpenSkyApi(object):
         if type(time_secs) == datetime:
             t = calendar.timegm(t.timetuple())
 
-        params = {"time": int(t), "icao24": icao24}
+        params = {"time": int(t), "icao24": icao24, "extended": True}
 
         if len(bbox) == 4:
             OpenSkyApi._check_lat(bbox[0])

--- a/python/opensky_api.py
+++ b/python/opensky_api.py
@@ -200,9 +200,10 @@ class OpenSkyApi(object):
         t = time_secs
         if type(time_secs) == datetime:
             t = calendar.timegm(t.timetuple())
+
+        params = {"time": int(t), "icao24": icao24, "serials": serials, "extended": True}
         states_json = self._get_json("/states/own", self.get_my_states,
-                                     params={"time": int(t), "icao24": icao24,
-                                                             "serials": serials})
+                                     params=params)
         if states_json is not None:
             return OpenSkyStates(states_json)
         return None

--- a/python/test_opensky_api.py
+++ b/python/test_opensky_api.py
@@ -65,23 +65,23 @@ class TestOpenSkyApi(TestCase):
         self.assertGreater(len(r.states), 0, "Retrieve at least one State Vector")
 
     def test_get_states_bbox_err(self):
-        with self.assertRaisesRegexp(ValueError, "Invalid bounding box!.*"):
+        with self.assertRaisesRegex(ValueError, "Invalid bounding box!.*"):
             self.api.get_states(bbox=(0, 0))
 
     def test_get_states_bbox_err_lat(self):
-        with self.assertRaisesRegexp(ValueError, "Invalid latitude 95.8389.*"):
+        with self.assertRaisesRegex(ValueError, "Invalid latitude 95.8389.*"):
             self.api.get_states(bbox=(95.8389, 47.8229, 5.9962, 10.5226))
-        with self.assertRaisesRegexp(ValueError, "Invalid latitude -147.8229.*"):
+        with self.assertRaisesRegex(ValueError, "Invalid latitude -147.8229.*"):
             self.api.get_states(bbox=(45.8389, -147.8229, 5.9962, 10.5226))
 
     def test_get_states_bbox_err_lon(self):
-        with self.assertRaisesRegexp(ValueError, "Invalid longitude -255.9962.*"):
+        with self.assertRaisesRegex(ValueError, "Invalid longitude -255.9962.*"):
             self.api.get_states(bbox=(45.8389, 47.8229, -255.9962, 10.5226))
-        with self.assertRaisesRegexp(ValueError, "Invalid longitude 210.5226.*"):
+        with self.assertRaisesRegex(ValueError, "Invalid longitude 210.5226.*"):
             self.api.get_states(bbox=(45.8389, 47.8229, 5.9962, 210.5226))
 
     def test_state_vector_parsing(self):
-        s = StateVector(["cabeef","ABCDEFG","USA",1001,1000,1.0,2.0,3.0,False,4.0,5.0,6.0,None,6743.7,"6714",False,0])
+        s = StateVector(["cabeef","ABCDEFG","USA",1001,1000,1.0,2.0,3.0,False,4.0,5.0,6.0,None,6743.7,"6714",False,0,0])
         self.assertEqual("cabeef", s.icao24)
         self.assertEqual("ABCDEFG", s.callsign)
         self.assertEqual("USA", s.origin_country)
@@ -91,7 +91,7 @@ class TestOpenSkyApi(TestCase):
         self.assertEqual(2.0, s.latitude)
         self.assertEqual(3.0, s.baro_altitude)
         self.assertEqual(4.0, s.velocity)
-        self.assertEqual(5.0, s.heading)
+        self.assertEqual(5.0, s.true_track)
         self.assertEqual(6.0, s.vertical_rate)
         self.assertFalse(s.on_ground)
         self.assertEqual(None, s.sensors)
@@ -99,10 +99,11 @@ class TestOpenSkyApi(TestCase):
         self.assertEqual("6714", s.squawk)
         self.assertFalse(s.spi)
         self.assertEqual(0, s.position_source)
+        self.assertEqual(0, s.category)
 
     def test_get_my_states_no_auth(self):
         a = OpenSkyApi()
-        with self.assertRaisesRegexp(Exception, "No username and password provided for get_my_states!"):
+        with self.assertRaisesRegex(Exception, "No username and password provided for get_my_states!"):
             a.get_my_states()
 
     @skipIf(len(TEST_USERNAME) < 1, "Missing credentials")


### PR DESCRIPTION
Added support for the vehicle category as described in the documentation of the REST API.  This includes setting the "extended" parameter in the API request to "True". Fixed error ("true_track" instead of "heading") in the test cases. Updated deprecated assert regex statement.