### PR TITLE
[Python] Add new request types available in the OpenSky REST API.

### DIFF
--- a/docs/free/python.rst
+++ b/docs/free/python.rst
@@ -9,12 +9,11 @@ See the README for installation instructions.
 Retrieving Data
 ---------------
 
-The API is encapsulated in a single class with two methods for retrieving
-:ref:`state vectors <state-vectors>`.
+The API is encapsulated in a single class with methods for data retrieving.
 
 .. module :: opensky_api
 .. autoclass :: OpenSkyApi
-    :members: __init__, get_states, get_my_states
+    :members: __init__, get_states, get_my_states, get_flights_from_interval, get_flights_by_aircraft, get_arrivals_by_airport, get_departures_by_airport, get_track_by_aircraft
 
 Return Types
 ------------
@@ -23,11 +22,18 @@ Return Types
 
 .. autoclass :: StateVector
 
+.. autoclass :: FlightData
+
+.. autoclass :: Waypoint
+
+.. autoclass :: FlightTrack
+
 
 Examples
 --------
 
-Without any authentication you should only retrieve state vectors every 10 seconds. Any higher rate is unnecessary due to the rate limitations and strongly advised against. Example for retrieving all states without authentication::
+Without any authentication you should only retrieve state vectors every 10 seconds. Any higher rate is unnecessary due
+to the rate limitations and strongly advised against. Example for retrieving all states without authentication::
 
     from opensky_api import OpenSkyApi
     
@@ -47,7 +53,9 @@ Example for retrieving all state vectors currently received by your receivers (n
     for s in states.states:
         print(s.sensors)
 
-It is also possible to retrieve state vectors for a certain area. For this purpose, you need to provide a bounding box. It is defined by lower and upper bounds for longitude and latitude. The following example shows how to retrieve data for a bounding box which encompasses Switzerland::
+It is also possible to retrieve state vectors for a certain area. For this purpose, you need to provide a bounding box.
+It is defined by lower and upper bounds for longitude and latitude. The following example shows how to retrieve data
+for a bounding box which encompasses Switzerland::
 
     from opensky_api import OpenSkyApi
     
@@ -56,3 +64,54 @@ It is also possible to retrieve state vectors for a certain area. For this purpo
     states = api.get_states(bbox=(45.8389, 47.8229, 5.9962, 10.5226))
     for s in states.states:
         print("(%r, %r, %r, %r)" % (s.longitude, s.latitude, s.baro_altitude, s.velocity))
+
+You can retrieve FlightData from a specific time interval, using the `get_flights_from_interval` method. To do this,
+provide the beginning and end of the time period, as a timestamps. It's important, that provided time interval must not
+be greater than 2 hours. The following example shows how to retrieve the FlightData frames from 12pm to 1pm on Jan 29
+2018::
+
+    from opensky_api import OpenSkyApi
+    api = OpenSkyApi()
+    data = api.get_flights_from_interval(1517227200, 1517230800)
+    for flight in data:
+        print(flight)
+
+The `get_flights_by_aircraft` method enables you to retrieve flights of a certain aircraft in time interval. To do this,
+specify the unique ICAO 24-bit aircraft address in hex string representation, the beginning and end of the time interval
+in the form of timestamps. The time interval must be smaller than 30 days. The example below shows steps to follow to
+get flights for D-AIZZ (3c675a), on Jan 29 2018::
+
+    from opensky_api import OpenSkyApi
+    api = OpenSkyApi()
+    data = api.get_flights_by_aircraft("3c675a", 1517184000, 1517270400)
+    for flight in data:
+        print(flight)
+
+It's possible to retrieve arrivals and departures for a specific airport and time interval, using
+`get_arrivals_by_airport` and `get_departures_by_airport` methods. Both methods require the ICAO identifier for the
+airport, start and end of the time period. The time interval must be smaller than 7 days. The following code shows how
+to retrieve the arrivals and departures at Frankfurt International Airport (EDDF) from 12pm to 1pm on Jan 29 2018::
+
+    from opensky_api import OpenSkyApi
+    api = OpenSkyApi()
+    arrivals = api.get_arrivals_by_airport("EDDF", 1517227200, 1517230800)
+    departures = api.get_departures_by_airport("EDDF", 1517227200, 1517230800)
+    print("Arrivals:")
+    for flight in arrivals:
+        print(flight)
+    print("Departures:")
+    for flight in departures:
+        print(flight)
+
+The `get_track_by_aircraft` method enables you to retrieve trajectory of the aircraft. Trajectory is given as a list of
+waypoints containing position, barometric altitude, true track and on-ground flag. In order to get the trajectory of the
+certain aircraft, you need to provide unique ICAO 24-bit aircraft address in hex string representation and optionally
+the timestamp between the start and end of a flight to be tracked. The default value of the timestamp, for the live
+tracking is 0. It is not possible to access flight tracks from more than 30 days in the past. The example below shows
+how to get the live track for aircraft with transponder address 3c4b26 (D-ABYF)::
+
+    from opensky_api import OpenSkyApi
+    api = OpenSkyApi()
+    track = api.get_track_by_aircraft("3c4b26")
+    print(track)
+

--- a/python/opensky_api.py
+++ b/python/opensky_api.py
@@ -29,7 +29,6 @@ import requests
 from datetime import datetime
 from collections import defaultdict
 import time
-from typing import Union
 
 logger = logging.getLogger("opensky_api")
 logger.addHandler(logging.NullHandler())
@@ -155,7 +154,7 @@ class FlightData(object):
         "arrivalAirportCandidatesCount",
     ]
 
-    def __init__(self, arr: list):
+    def __init__(self, arr):
         """
         Function that initializes the FlightData object.
 
@@ -192,7 +191,7 @@ class Waypoint(object):
         "on_ground",
     ]
 
-    def __init__(self, arr: list):
+    def __init__(self, arr):
         """
         Function that initializes the Waypoint object.
 
@@ -219,7 +218,7 @@ class FlightTrack(object):
 
     """
 
-    def __init__(self, arr: dict):
+    def __init__(self, arr):
         """
         Function that initializes the FlightTrack object.
 
@@ -366,7 +365,7 @@ class OpenSkyApi(object):
             return OpenSkyStates(states_json)
         return None
 
-    def get_flighs_from_interval(self, begin: int, end: int) -> list[FlightData]:
+    def get_flighs_from_interval(self, begin, end):
         """
         Retrieves data of flights for certain time interval [begin, end].
         :param begin: Start of time interval to retrieve flights for as Unix time (seconds since epoch).
@@ -385,9 +384,9 @@ class OpenSkyApi(object):
 
         if states_json is not None:
             return [FlightData(list(entry.values())) for entry in states_json]
-        return []
+        return None
 
-    def get_flighs_by_aircraft(self, icao24: str, begin: int, end: int) -> list[FlightData]:
+    def get_flighs_by_aircraft(self, icao24, begin, end):
         """
         Retrievs data of flights for certain aircraft and time interval.
         :param icao24: Unique ICAO 24-bit address of the transponder in hex string representation.
@@ -410,9 +409,9 @@ class OpenSkyApi(object):
 
         if states_json is not None:
             return [FlightData(list(entry.values())) for entry in states_json]
-        return []
+        return None
 
-    def get_arrivals_by_airport(self, airport: str, begin: int, end: int) -> list[FlightData]:
+    def get_arrivals_by_airport(self, airport, begin, end):
         """
         Retrieve flights for a certain airport which arrived within a given time interval [begin, end].
         :param airport: ICAO identier for the airport
@@ -433,9 +432,9 @@ class OpenSkyApi(object):
 
         if states_json is not None:
             return [FlightData(list(entry.values())) for entry in states_json]
-        return []
+        return None
 
-    def get_departures_by_airport(self, airport: str, begin: int, end: int) -> list[FlightData]:
+    def get_departures_by_airport(self, airport, begin, end):
         """
         Retrieve flights for a certain airport which arrived within a given time interval [begin, end].
         :param airport: ICAO identier for the airport
@@ -458,7 +457,7 @@ class OpenSkyApi(object):
             return [FlightData(list(entry.values())) for entry in states_json]
         return []
 
-    def get_track_by_aircraft(self, icao24: str, t: int = 0) -> Union[FlightTrack, type(None)]:
+    def get_track_by_aircraft(self, icao24, t=0):
         """
         Retrieve flights for a certain airport which arrived within a given time interval [begin, end].
         :param icao24: Unique ICAO 24-bit address of the transponder in hex string representation.

--- a/python/opensky_api.py
+++ b/python/opensky_api.py
@@ -37,27 +37,27 @@ logger.addHandler(logging.NullHandler())
 class StateVector(object):
     """ Represents the state of a vehicle at a particular time. It has the following fields:
 
-      |  **icao24** - ICAO24 address of the transmitter in hex string representation.
-      |  **callsign** - callsign of the vehicle. Can be None if no callsign has been received.
-      |  **origin_country** - inferred through the ICAO24 address
-      |  **time_position** - seconds since epoch of last position report. Can be None if there was no position report
+      |  **icao24**: `str` - ICAO24 address of the transmitter in hex string representation.
+      |  **callsign**: `str` - callsign of the vehicle. Can be None if no callsign has been received.
+      |  **origin_country**: `str` - inferred through the ICAO24 address
+      |  **time_position**: `int` - seconds since epoch of last position report. Can be None if there was no position report
         received by OpenSky within 15s before.
-      |  **last_contact** - seconds since epoch of last received message from this transponder
-      |  **longitude** - in ellipsoidal coordinates (WGS-84) and degrees. Can be None
-      |  **latitude** - in ellipsoidal coordinates (WGS-84) and degrees. Can be None
-      |  **geo_altitude** - geometric altitude in meters. Can be None
-      |  **on_ground** - true if aircraft is on ground (sends ADS-B surface position reports).
-      |  **velocity** - over ground in m/s. Can be None if information not present
-      |  **true_track** - in decimal degrees (0 is north). Can be None if information not present.
-      |  **vertical_rate** - in m/s, incline is positive, decline negative. Can be None if information not present.
-      |  **sensors** - serial numbers of sensors which received messages from the vehicle within the validity period of
+      |  **last_contact**: `int` - seconds since epoch of last received message from this transponder
+      |  **longitude**: `float` - in ellipsoidal coordinates (WGS-84) and degrees. Can be None
+      |  **latitude**: `float` - in ellipsoidal coordinates (WGS-84) and degrees. Can be None
+      |  **geo_altitude**: `float` - geometric altitude in meters. Can be None
+      |  **on_ground**: `bool` - true if aircraft is on ground (sends ADS-B surface position reports).
+      |  **velocity**: `float` - over ground in m/s. Can be None if information not present
+      |  **true_track**: `float` - in decimal degrees (0 is north). Can be None if information not present.
+      |  **vertical_rate**: `float` - in m/s, incline is positive, decline negative. Can be None if information not present.
+      |  **sensors**: `list` [`int`] - serial numbers of sensors which received messages from the vehicle within the validity period of
         this state vector. Can be None if no filtering for sensor has been requested.
-      |  **baro_altitude** - barometric altitude in meters. Can be None
-      |  **squawk** - transponder code aka Squawk. Can be None
-      |  **spi** - special purpose indicator
-      |  **position_source** - origin of this state's position: 0 = ADS-B, 1 = ASTERIX, 2 = MLAT, 3 = FLARM
-      |  **category** - aircraft category: 0 = No information at all, 1 = No ADS-B Emitter Category Information,
-      ||  2 = Light (< 15500 lbs), 3 = Small (15500 to 75000 lbs), 4 = Large (75000 to 300000 lbs),
+      |  **baro_altitude**: `float` - barometric altitude in meters. Can be None
+      |  **squawk**: `str` - transponder code aka Squawk. Can be None
+      |  **spi**: `bool` - special purpose indicator
+      |  **position_source**: `int` - origin of this state's position: 0 = ADS-B, 1 = ASTERIX, 2 = MLAT, 3 = FLARM
+      |  **category**: `int` - aircraft category: 0 = No information at all, 1 = No ADS-B Emitter Category Information,
+        2 = Light (< 15500 lbs), 3 = Small (15500 to 75000 lbs), 4 = Large (75000 to 300000 lbs),
         5 = High Vortex Large (aircraft such as B-757), 6 = Heavy (> 300000 lbs),
         7 = High Performance (> 5g acceleration and 400 kts), 8 = Rotorcraft, 9 = Glider / sailplane,
         10 = Lighter-than-air, 11 = Parachutist / Skydiver, 12 = Ultralight / hang-glider / paraglider,
@@ -90,7 +90,10 @@ class StateVector(object):
     # We are not using namedtuple here as state vectors from the server might be extended; zip() will ignore additional
     #  entries in this case
     def __init__(self, arr):
-        """arr is the array representation of a state vector as received by the API"""
+        """
+        Initializes the StateVector object.
+        :param list arr: the array representation of a state vector as received by the API
+        """
         self.__dict__ = dict(zip(StateVector.keys, arr))
 
     def __repr__(self):
@@ -103,11 +106,15 @@ class StateVector(object):
 class OpenSkyStates(object):
     """ Represents the state of the airspace as seen by OpenSky at a particular time. It has the following fields:
 
-      |  **time** - in seconds since epoch (Unix time stamp). Gives the validity period of all states.
+      |  **time**: `int` - in seconds since epoch (Unix time stamp). Gives the validity period of all states.
         All vectors represent the state of a vehicle with the interval :math:`[time - 1, time]`.
-      |  **states** - a list of `StateVector` or is None if there have been no states received
+      |  **states**: `list` [`StateVector`] - a list of `StateVector` or is None if there have been no states received
     """
     def __init__(self, j):
+        """
+        Initializes the OpenSkyStates object
+        :param dict j: the json represents the state of the airspace as seen by OpenSky at a particular time
+        """
         self.__dict__ = j
         if self.states is not None:
             self.states = [StateVector(a) for a in self.states]
@@ -125,29 +132,28 @@ class FlightData(object):
     """
     Class that represents data of certain flight. It has the following fields:
 
-    |  **icao24** - Unique ICAO 24-bit address of the transponder in hex string representation.
+    |  **icao24**: `str` - Unique ICAO 24-bit address of the transponder in hex string representation.
         All letters are lower case.
-    |  **firstSeen** - Estimated time of departure for the flight as Unix time (seconds since epoch).
-    |  **estDepartureAirport** - ICAO code of the estimated departure airport.
+    |  **firstSeen**: `int` - Estimated time of departure for the flight as Unix time (seconds since epoch).
+    |  **estDepartureAirport**: `str` - ICAO code of the estimated departure airport.
         Can be null if the airport could not be identified.
-    |  **lastSeen** - Estimated time of arrival for the flight as Unix time (seconds since epoch).
-    |  **estArrivalAirport** - ICAO code of the estimated arrival airport.
+    |  **lastSeen**: `int` - Estimated time of arrival for the flight as Unix time (seconds since epoch).
+    |  **estArrivalAirport**: `str` - ICAO code of the estimated arrival airport.
         Can be null if the airport could not be identified.
-    |  **callsign** - Callsign of the vehicle (8 chars). Can be null if no callsign has been received.
+    |  **callsign**: `str` - Callsign of the vehicle (8 chars). Can be null if no callsign has been received.
         If the vehicle transmits multiple callsigns during the flight, we take the one seen most frequently.
-    |  **estDepartureAirportHorizDistance** - Horizontal distance of the last received airborne position to the
+    |  **estDepartureAirportHorizDistance**: `int` - Horizontal distance of the last received airborne position to the
         estimated departure airport in meters.
-    |  **estDepartureAirportVertDistance** - Vertical distance of the last received airborne position to the
+    |  **estDepartureAirportVertDistance**: `int` - Vertical distance of the last received airborne position to the
         estimated departure airport in meters.
-    |  **estArrivalAirportHorizDistance** - Horizontal distance of the last received airborne position to the
+    |  **estArrivalAirportHorizDistance**: `int` - Horizontal distance of the last received airborne position to the
         estimated arrival airport in meters.
-    |  **estArrivalAirportVertDistance** - Vertical distance of the last received airborne position to the
+    |  **estArrivalAirportVertDistance**: `int` - Vertical distance of the last received airborne position to the
         estimated arrival airport in meters.
-    |  **departureAirportCandidatesCount** - Number of other possible departure airports. These are airports in short
+    |  **departureAirportCandidatesCount**: `int` - Number of other possible departure airports. These are airports in short
         distance to estDepartureAirport.
-    |  **arrivalAirportCandidatesCount** - Number of other possible departure airports. These are airports in short
+    |  **arrivalAirportCandidatesCount**: `int` - Number of other possible departure airports. These are airports in short
         distance to estArrivalAirport.
-
     """
 
     keys = [
@@ -169,7 +175,7 @@ class FlightData(object):
         """
         Function that initializes the FlightData object.
 
-        :param arr: array representation of a flight data as received by the API.
+        :param list arr: array representation of a flight data as received by the API.
         """
         self.__dict__ = dict(zip(FlightData.keys, arr))
 
@@ -184,13 +190,12 @@ class Waypoint(object):
     """
     Class that represents the singnle waypoint that is a basic part of flight trajectory:
 
-    |  **time** - Time which the given waypoint is associated with in seconds since epoch (Unix time).
-    |  **latitude** - WGS-84 latitude in decimal degrees. Can be null.
-    |  **longitude** - WGS-84 longitude in decimal degrees. Can be null.
-    |  **baro_altitude** - Barometric altitude in meters. Can be null.
-    |  **true_track** - True track in decimal degrees clockwise from north (north=0°). Can be null.
-    |  **on_ground** - Boolean value which indicates if the position was retrieved from a surface position report.
-
+    |  **time**: `int` - Time which the given waypoint is associated with in seconds since epoch (Unix time).
+    |  **latitude**: `float` - WGS-84 latitude in decimal degrees. Can be null.
+    |  **longitude**: `float` - WGS-84 longitude in decimal degrees. Can be null.
+    |  **baro_altitude**: `float` - Barometric altitude in meters. Can be null.
+    |  **true_track**: `float` - True track in decimal degrees clockwise from north (north=0°). Can be null.
+    |  **on_ground**: `bool` - Boolean value which indicates if the position was retrieved from a surface position report.
     """
 
     keys = [
@@ -206,7 +211,7 @@ class Waypoint(object):
         """
         Function that initializes the Waypoint object.
 
-        :param arr: array representation of a single waypoint as received by the API.
+        :param list arr: array representation of a single waypoint as received by the API.
         """
         self.__dict__ = dict(zip(Waypoint.keys, arr))
 
@@ -221,20 +226,18 @@ class FlightTrack(object):
     """
     Class that represents the trajectory for a certain aircraft at a given time.:
 
-    |  **icao24** - Unique ICAO 24-bit address of the transponder in lower case hex string representation.
-    |  **startTime** - Time of the first waypoint in seconds since epoch (Unix time).
-    |  **endTime** - Time of the last waypoint in seconds since epoch (Unix time).
-    |  **calllsign** - Callsign (8 characters) that holds for the whole track. Can be null.
-    |  **path** - waypoints of the trajectory (description below).
-
+    |  **icao24**: `str` - Unique ICAO 24-bit address of the transponder in lower case hex string representation.
+    |  **startTime**: `int` - Time of the first waypoint in seconds since epoch (Unix time).
+    |  **endTime**: `int` - Time of the last waypoint in seconds since epoch (Unix time).
+    |  **calllsign**: `str` - Callsign (8 characters) that holds for the whole track. Can be null.
+    |  **path**: `list` [`Waypoint`] - waypoints of the trajectory.
     """
 
     def __init__(self, arr):
         """
         Function that initializes the FlightTrack object.
 
-        :param arr: array representation of the flight track received by the API.
-
+        :param list arr: array representation of the flight track received by the API.
         """
         for key, value in arr.items():
             if key == "path":
@@ -257,8 +260,8 @@ class OpenSkyApi(object):
         """Create an instance of the API client. If you do not provide username and password requests will be
         anonymous which imposes some limitations.
 
-        :param username: an OpenSky username (optional)
-        :param password: an OpenSky password for the given username (optional)
+        :param str username: an OpenSky username (optional)
+        :param str password: an OpenSky password for the given username (optional)
         """
         if username is not None:
             self._auth = (username, password)
@@ -268,6 +271,14 @@ class OpenSkyApi(object):
         self._last_requests = defaultdict(lambda: 0)
 
     def _get_json(self, url_post, callee, params=None):
+        """
+        Sends HTTP request to the given endpoint and returns the response as a json
+
+        :param str url_post: endpoint to which the request will be sent
+        :param Callable callee: method that calls _get_json()
+        :param dict params: request parameters
+        :rtype: dict|None
+        """
         r = requests.get(
             "{0:s}{1:s}".format(self._api_url, url_post),
             auth=self._auth,
@@ -284,11 +295,13 @@ class OpenSkyApi(object):
         return None
 
     def _check_rate_limit(self, time_diff_noauth, time_diff_auth, func):
-        """impose client-side rate limit
+        """
+        Impose client-side rate limit
 
-        :param time_diff_noauth: the minimum time between two requests in seconds if not using authentication
-        :param time_diff_auth: the minimum time between two requests in seconds if using authentication
-        :param func: the API function to evaluate
+        :param int time_diff_noauth: the minimum time between two requests in seconds if not using authentication
+        :param int time_diff_auth: the minimum time between two requests in seconds if using authentication
+        :param callable func: the API function to evaluate
+        :rtype: bool
         """
         if len(self._auth) < 2:
             return abs(time.time() - self._last_requests[func]) >= time_diff_noauth
@@ -308,16 +321,18 @@ class OpenSkyApi(object):
             )
 
     def get_states(self, time_secs=0, icao24=None, bbox=()):
-        """Retrieve state vectors for a given time. If time = 0 the most recent ones are taken.
+        """
+        Retrieve state vectors for a given time. If time = 0 the most recent ones are taken.
         Optional filters may be applied for ICAO24 addresses.
 
-        :param time_secs: time as Unix time stamp (seconds since epoch) or datetime. The datetime must be in UTC!
-        :param icao24: optionally retrieve only state vectors for the given ICAO24 address(es).
+        :param int time_secs: time as Unix time stamp (seconds since epoch) or datetime. The datetime must be in UTC!
+        :param str icao24: optionally retrieve only state vectors for the given ICAO24 address(es).
             The parameter can either be a single address as str or an array of str containing multiple addresses
-        :param bbox: optionally retrieve state vectors within a bounding box.
+        :param tuple bbox: optionally retrieve state vectors within a bounding box.
             The bbox must be a tuple of exactly four values [min_latitude, max_latitude, min_longitude, max_longitude]
             each in WGS84 decimal degrees.
         :return: OpenSkyStates if request was successful, None otherwise
+        :rtype: OpenSkyStates | None
         """
         if not self._check_rate_limit(10, 5, self.get_states):
             logger.debug("Blocking request due to rate limit")
@@ -350,16 +365,18 @@ class OpenSkyApi(object):
         return None
 
     def get_my_states(self, time_secs=0, icao24=None, serials=None):
-        """Retrieve state vectors for your own sensors. Authentication is required for this operation.
+        """
+        Retrieve state vectors for your own sensors. Authentication is required for this operation.
         If time = 0 the most recent ones are taken. Optional filters may be applied for ICAO24 addresses and sensor
         serial numbers.
 
-        :param time_secs: time as Unix time stamp (seconds since epoch) or datetime. The datetime must be in UTC!
-        :param icao24: optionally retrieve only state vectors for the given ICAO24 address(es).
+        :param int time_secs: time as Unix time stamp (seconds since epoch) or datetime. The datetime must be in UTC!
+        :param str icao24: optionally retrieve only state vectors for the given ICAO24 address(es).
             The parameter can either be a single address as str or an array of str containing multiple addresses
-        :param serials: optionally retrieve only states of vehicles as seen by the given sensor(s).
+        :param int serials: optionally retrieve only states of vehicles as seen by the given sensor(s).
             The parameter can either be a single sensor serial number (int) or a list of serial numbers.
         :return: OpenSkyStates if request was successful, None otherwise
+        :rtype: OpenSkyStates | None
         """
         if len(self._auth) < 2:
             raise Exception("No username and password provided for get_my_states!")
@@ -384,9 +401,11 @@ class OpenSkyApi(object):
     def get_flights_from_interval(self, begin, end):
         """
         Retrieves data of flights for certain time interval [begin, end].
-        :param begin: Start of time interval to retrieve flights for as Unix time (seconds since epoch).
-        :param end: End of time interval to retrieve flights for as Unix time (seconds since epoch).
-        :return: list of `FlightData` objects, created based on flights from given time interval.
+
+        :param int begin: Start of time interval to retrieve flights for as Unix time (seconds since epoch).
+        :param int end: End of time interval to retrieve flights for as Unix time (seconds since epoch).
+        :return: list of FlightData objects if request was successful, None otherwise.
+        :rtype: FlightData | None
         """
         if begin >= end:
             raise ValueError("The end parameter must be greater than begin")
@@ -404,13 +423,14 @@ class OpenSkyApi(object):
 
     def get_flights_by_aircraft(self, icao24, begin, end):
         """
-        Retrievs data of flights for certain aircraft and time interval.
-        :param icao24: Unique ICAO 24-bit address of the transponder in hex string representation.
-            All letters need to be lower case
-        :param begin: Start of time interval to retrieve flights for as Unix time (seconds since epoch).
-        :param end: End of time interval to retrieve flights for as Unix time (seconds since epoch).
-        :return: list of FlightData objects.
+        Retrieves data of flights for certain aircraft and time interval.
 
+        :param str icao24: Unique ICAO 24-bit address of the transponder in hex string representation.
+            All letters need to be lower case
+        :param int begin: Start of time interval to retrieve flights for as Unix time (seconds since epoch).
+        :param int end: End of time interval to retrieve flights for as Unix time (seconds since epoch).
+        :return: list of FlightData objects if request was successful, None otherwise.
+        :rtype: FlightData | None
         """
 
         if begin >= end:
@@ -429,12 +449,13 @@ class OpenSkyApi(object):
 
     def get_arrivals_by_airport(self, airport, begin, end):
         """
-        Retrieve flights for a certain airport which arrived within a given time interval [begin, end].
-        :param airport: ICAO identier for the airport
-        :param begin: Start of time interval to retrieve flights for as Unix time (seconds since epoch)
-        :param end: End of time interval to retrieve flights for as Unix time (seconds since epoch)
-        :return: list of FlightData objects.
+        Retrieves flights for a certain airport which arrived within a given time interval [begin, end].
 
+        :param str airport: ICAO identier for the airport
+        :param int begin: Start of time interval to retrieve flights for as Unix time (seconds since epoch)
+        :param int end: End of time interval to retrieve flights for as Unix time (seconds since epoch)
+        :return: list of FlightData objects if request was successful, None otherwise.
+        :rtype: FlightData | None
         """
         if begin >= end:
             raise ValueError("The end parameter must be greater than begin")
@@ -452,12 +473,13 @@ class OpenSkyApi(object):
 
     def get_departures_by_airport(self, airport, begin, end):
         """
-        Retrieve flights for a certain airport which arrived within a given time interval [begin, end].
-        :param airport: ICAO identier for the airport
-        :param begin: Start of time interval to retrieve flights for as Unix time (seconds since epoch)
-        :param end: End of time interval to retrieve flights for as Unix time (seconds since epoch)
-        :return: list of FlightData objects.
+        Retrieves flights for a certain airport which arrived within a given time interval [begin, end].
 
+        :param str airport: ICAO identier for the airport
+        :param int begin: Start of time interval to retrieve flights for as Unix time (seconds since epoch)
+        :param int end: End of time interval to retrieve flights for as Unix time (seconds since epoch)
+        :return: list of FlightData objects if request was successful, None otherwise.
+        :rtype: FlightData | None
         """
         if begin >= end:
             raise ValueError("The end parameter must be greater than begin")
@@ -475,15 +497,15 @@ class OpenSkyApi(object):
 
     def get_track_by_aircraft(self, icao24, t=0):
         """
-        Retrieve flights for a certain airport which arrived within a given time interval [begin, end].
+        Retrieves flights for a certain airport which arrived within a given time interval [begin, end].
         **The tracks endpoint is purely experimental.**
 
-        :param icao24: Unique ICAO 24-bit address of the transponder in hex string representation.
+        :param str icao24: Unique ICAO 24-bit address of the transponder in hex string representation.
             All letters need to be lower case
-        :param t: Unix time in seconds since epoch. It can be any time between start and end of a known flight.
+        :param int t: Unix time in seconds since epoch. It can be any time between start and end of a known flight.
             If time = 0, get the live track if there is any flight ongoing for the given aircraft.
-        :return: FlightTrack object
-
+        :return: FlightTrack object if request was successful, None otherwise.
+        :rtype: FlightTrack | None
         """
         if int(time.time()) - t > 2592*1e3 and t != 0:
             raise ValueError("It is not possible to access flight tracks from more than 30 days in the past.")

--- a/python/opensky_api.py
+++ b/python/opensky_api.py
@@ -503,7 +503,7 @@ class OpenSkyApi(object):
 
     def get_track_by_aircraft(self, icao24, t=0):
         """
-        Retrieves flights for a certain airport which arrived within a given time interval [begin, end].
+        Retrieve the trajectory for a certain aircraft at a given time.
         **The tracks endpoint is purely experimental.**
 
         :param str icao24: Unique ICAO 24-bit address of the transponder in hex string representation.

--- a/python/opensky_api.py
+++ b/python/opensky_api.py
@@ -40,7 +40,8 @@ class StateVector(object):
       |  **icao24** - ICAO24 address of the transmitter in hex string representation.
       |  **callsign** - callsign of the vehicle. Can be None if no callsign has been received.
       |  **origin_country** - inferred through the ICAO24 address
-      |  **time_position** - seconds since epoch of last position report. Can be None if there was no position report received by OpenSky within 15s before.
+      |  **time_position** - seconds since epoch of last position report. Can be None if there was no position report
+        received by OpenSky within 15s before.
       |  **last_contact** - seconds since epoch of last received message from this transponder
       |  **longitude** - in ellipsoidal coordinates (WGS-84) and degrees. Can be None
       |  **latitude** - in ellipsoidal coordinates (WGS-84) and degrees. Can be None
@@ -49,12 +50,20 @@ class StateVector(object):
       |  **velocity** - over ground in m/s. Can be None if information not present
       |  **true_track** - in decimal degrees (0 is north). Can be None if information not present.
       |  **vertical_rate** - in m/s, incline is positive, decline negative. Can be None if information not present.
-      |  **sensors** - serial numbers of sensors which received messages from the vehicle within the validity period of this state vector. Can be None if no filtering for sensor has been requested.
+      |  **sensors** - serial numbers of sensors which received messages from the vehicle within the validity period of
+        this state vector. Can be None if no filtering for sensor has been requested.
       |  **baro_altitude** - barometric altitude in meters. Can be None
       |  **squawk** - transponder code aka Squawk. Can be None
       |  **spi** - special purpose indicator
       |  **position_source** - origin of this state's position: 0 = ADS-B, 1 = ASTERIX, 2 = MLAT, 3 = FLARM
-      |  **category** - aircraft category: 0 = No information at all, 1 = No ADS-B Emitter Category Information, 2 = Light (< 15500 lbs), 3 = Small (15500 to 75000 lbs), 4 = Large (75000 to 300000 lbs), 5 = High Vortex Large (aircraft such as B-757), 6 = Heavy (> 300000 lbs), 7 = High Performance (> 5g acceleration and 400 kts), 8 = Rotorcraft, 9 = Glider / sailplane, 10 = Lighter-than-air, 11 = Parachutist / Skydiver, 12 = Ultralight / hang-glider / paraglider, 13 = Reserved, 14 = Unmanned Aerial Vehicle, 15 = Space / Trans-atmospheric vehicle, 16 = Surface Vehicle – Emergency Vehicle, 17 = Surface Vehicle – Service Vehicle, 18 = Point Obstacle (includes tethered balloons), 19 = Cluster Obstacle, 20 = Line Obstacle
+      |  **category** - aircraft category: 0 = No information at all, 1 = No ADS-B Emitter Category Information,
+      ||  2 = Light (< 15500 lbs), 3 = Small (15500 to 75000 lbs), 4 = Large (75000 to 300000 lbs),
+        5 = High Vortex Large (aircraft such as B-757), 6 = Heavy (> 300000 lbs),
+        7 = High Performance (> 5g acceleration and 400 kts), 8 = Rotorcraft, 9 = Glider / sailplane,
+        10 = Lighter-than-air, 11 = Parachutist / Skydiver, 12 = Ultralight / hang-glider / paraglider,
+        13 = Reserved, 14 = Unmanned Aerial Vehicle, 15 = Space / Trans-atmospheric vehicle,
+        16 = Surface Vehicle – Emergency Vehicle, 17 = Surface Vehicle – Service Vehicle,
+        18 = Point Obstacle (includes tethered balloons), 19 = Cluster Obstacle, 20 = Line Obstacle
     """
 
     keys = [
@@ -94,7 +103,8 @@ class StateVector(object):
 class OpenSkyStates(object):
     """ Represents the state of the airspace as seen by OpenSky at a particular time. It has the following fields:
 
-      |  **time** - in seconds since epoch (Unix time stamp). Gives the validity period of all states. All vectors represent the state of a vehicle with the interval :math:`[time - 1, time]`.
+      |  **time** - in seconds since epoch (Unix time stamp). Gives the validity period of all states.
+        All vectors represent the state of a vehicle with the interval :math:`[time - 1, time]`.
       |  **states** - a list of `StateVector` or is None if there have been no states received
     """
     def __init__(self, j):
@@ -115,7 +125,8 @@ class FlightData(object):
     """
     Class that represents data of certain flight. It has the following fields:
 
-    |  **icao24** - Unique ICAO 24-bit address of the transponder in hex string representation. All letters are lower case.
+    |  **icao24** - Unique ICAO 24-bit address of the transponder in hex string representation.
+        All letters are lower case.
     |  **firstSeen** - Estimated time of departure for the flight as Unix time (seconds since epoch).
     |  **estDepartureAirport** - ICAO code of the estimated departure airport.
         Can be null if the airport could not be identified.
@@ -301,8 +312,11 @@ class OpenSkyApi(object):
         Optional filters may be applied for ICAO24 addresses.
 
         :param time_secs: time as Unix time stamp (seconds since epoch) or datetime. The datetime must be in UTC!
-        :param icao24: optionally retrieve only state vectors for the given ICAO24 address(es). The parameter can either be a single address as str or an array of str containing multiple addresses
-        :param bbox: optionally retrieve state vectors within a bounding box. The bbox must be a tuple of exactly four values [min_latitude, max_latitude, min_longitude, max_latitude] each in WGS84 decimal degrees.
+        :param icao24: optionally retrieve only state vectors for the given ICAO24 address(es).
+            The parameter can either be a single address as str or an array of str containing multiple addresses
+        :param bbox: optionally retrieve state vectors within a bounding box.
+            The bbox must be a tuple of exactly four values [min_latitude, max_latitude, min_longitude, max_longitude]
+            each in WGS84 decimal degrees.
         :return: OpenSkyStates if request was successful, None otherwise
         """
         if not self._check_rate_limit(10, 5, self.get_states):
@@ -327,7 +341,7 @@ class OpenSkyApi(object):
             params["lomax"] = bbox[3]
         elif len(bbox) > 0:
             raise ValueError(
-                "Invalid bounding box! Must be [min_latitude, max_latitude, min_longitude, max_latitude]"
+                "Invalid bounding box! Must be [min_latitude, max_latitude, min_longitude, max_longitude]"
             )
 
         states_json = self._get_json("/states/all", self.get_states, params=params)
@@ -341,8 +355,10 @@ class OpenSkyApi(object):
         serial numbers.
 
         :param time_secs: time as Unix time stamp (seconds since epoch) or datetime. The datetime must be in UTC!
-        :param icao24: optionally retrieve only state vectors for the given ICAO24 address(es). The parameter can either be a single address as str or an array of str containing multiple addresses
-        :param serials: optionally retrieve only states of vehicles as seen by the given sensor(s). The parameter can either be a single sensor serial number (int) or a list of serial numbers.
+        :param icao24: optionally retrieve only state vectors for the given ICAO24 address(es).
+            The parameter can either be a single address as str or an array of str containing multiple addresses
+        :param serials: optionally retrieve only states of vehicles as seen by the given sensor(s).
+            The parameter can either be a single sensor serial number (int) or a list of serial numbers.
         :return: OpenSkyStates if request was successful, None otherwise
         """
         if len(self._auth) < 2:
@@ -365,7 +381,7 @@ class OpenSkyApi(object):
             return OpenSkyStates(states_json)
         return None
 
-    def get_flighs_from_interval(self, begin, end):
+    def get_flights_from_interval(self, begin, end):
         """
         Retrieves data of flights for certain time interval [begin, end].
         :param begin: Start of time interval to retrieve flights for as Unix time (seconds since epoch).
@@ -379,14 +395,14 @@ class OpenSkyApi(object):
 
         params = {"begin": begin, "end": end}
         states_json = self._get_json(
-            "/flights/all", self.get_flighs_from_interval, params=params
+            "/flights/all", self.get_flights_from_interval, params=params
         )
 
         if states_json is not None:
             return [FlightData(list(entry.values())) for entry in states_json]
         return None
 
-    def get_flighs_by_aircraft(self, icao24, begin, end):
+    def get_flights_by_aircraft(self, icao24, begin, end):
         """
         Retrievs data of flights for certain aircraft and time interval.
         :param icao24: Unique ICAO 24-bit address of the transponder in hex string representation.
@@ -404,7 +420,7 @@ class OpenSkyApi(object):
 
         params = {"icao24": icao24, "begin": begin, "end": end}
         states_json = self._get_json(
-            "/flights/aircraft", self.get_flighs_by_aircraft, params=params
+            "/flights/aircraft", self.get_flights_by_aircraft, params=params
         )
 
         if states_json is not None:

--- a/python/opensky_api.py
+++ b/python/opensky_api.py
@@ -460,6 +460,8 @@ class OpenSkyApi(object):
     def get_track_by_aircraft(self, icao24, t=0):
         """
         Retrieve flights for a certain airport which arrived within a given time interval [begin, end].
+        **The tracks endpoint is purely experimental.**
+
         :param icao24: Unique ICAO 24-bit address of the transponder in hex string representation.
             All letters need to be lower case
         :param t: Unix time in seconds since epoch. It can be any time between start and end of a known flight.

--- a/python/opensky_api.py
+++ b/python/opensky_api.py
@@ -36,35 +36,26 @@ logger.addHandler(logging.NullHandler())
 
 
 class StateVector(object):
-    """Represents the state of a vehicle at a particular time. It has the following fields:
+    """ Represents the state of a vehicle at a particular time. It has the following fields:
 
-    |  **icao24** - ICAO24 address of the transmitter in hex string representation.
-    |  **callsign** - callsign of the vehicle. Can be None if no callsign has been received.
-    |  **origin_country** - inferred through the ICAO24 address
-    |  **time_position** - seconds since epoch of last position report. Can be None if there was no position report
-      received by OpenSky within 15s before.
-    |  **last_contact** - seconds since epoch of last received message from this transponder
-    |  **longitude** - in ellipsoidal coordinates (WGS-84) and degrees. Can be None
-    |  **latitude** - in ellipsoidal coordinates (WGS-84) and degrees. Can be None
-    |  **geo_altitude** - geometric altitude in meters. Can be None
-    |  **on_ground** - true if aircraft is on ground (sends ADS-B surface position reports).
-    |  **velocity** - over ground in m/s. Can be None if information not present
-    |  **true_track** - in decimal degrees (0 is north). Can be None if information not present.
-    |  **vertical_rate** - in m/s, incline is positive, decline negative. Can be None if information not present.
-    |  **sensors** - serial numbers of sensors which received messages from the vehicle within the validity period of
-      this state vector. Can be None if no filtering for sensor has been requested.
-    |  **baro_altitude** - barometric altitude in meters. Can be None
-    |  **squawk** - transponder code aka Squawk. Can be None
-    |  **spi** - special purpose indicator
-    |  **position_source** - origin of this state's position: 0 = ADS-B, 1 = ASTERIX, 2 = MLAT, 3 = FLARM
-    |  **category** - aircraft category: 0 = No information at all, 1 = No ADS-B Emitter Category Information,
-        2 = Light (< 15500 lbs), 3 = Small (15500 to 75000 lbs), 4 = Large (75000 to 300000 lbs),
-        5 = High Vortex Large (aircraft such as B-757), 6 = Heavy (> 300000 lbs),
-        7 = High Performance (> 5g acceleration and 400 kts), 8 = Rotorcraft, 9 = Glider / sailplane,
-        10 = Lighter-than-air, 11 = Parachutist / Skydiver, 12 = Ultralight / hang-glider / paraglider, 13 = Reserved,
-        14 = Unmanned Aerial Vehicle, 15 = Space / Trans-atmospheric vehicle, 16 = Surface Vehicle – Emergency Vehicle,
-          17 = Surface Vehicle – Service Vehicle, 18 = Point Obstacle (includes tethered balloons), 19 = Cluster Obstacle,
-         20 = Line Obstacle
+      |  **icao24** - ICAO24 address of the transmitter in hex string representation.
+      |  **callsign** - callsign of the vehicle. Can be None if no callsign has been received.
+      |  **origin_country** - inferred through the ICAO24 address
+      |  **time_position** - seconds since epoch of last position report. Can be None if there was no position report received by OpenSky within 15s before.
+      |  **last_contact** - seconds since epoch of last received message from this transponder
+      |  **longitude** - in ellipsoidal coordinates (WGS-84) and degrees. Can be None
+      |  **latitude** - in ellipsoidal coordinates (WGS-84) and degrees. Can be None
+      |  **geo_altitude** - geometric altitude in meters. Can be None
+      |  **on_ground** - true if aircraft is on ground (sends ADS-B surface position reports).
+      |  **velocity** - over ground in m/s. Can be None if information not present
+      |  **true_track** - in decimal degrees (0 is north). Can be None if information not present.
+      |  **vertical_rate** - in m/s, incline is positive, decline negative. Can be None if information not present.
+      |  **sensors** - serial numbers of sensors which received messages from the vehicle within the validity period of this state vector. Can be None if no filtering for sensor has been requested.
+      |  **baro_altitude** - barometric altitude in meters. Can be None
+      |  **squawk** - transponder code aka Squawk. Can be None
+      |  **spi** - special purpose indicator
+      |  **position_source** - origin of this state's position: 0 = ADS-B, 1 = ASTERIX, 2 = MLAT, 3 = FLARM
+      |  **category** - aircraft category: 0 = No information at all, 1 = No ADS-B Emitter Category Information, 2 = Light (< 15500 lbs), 3 = Small (15500 to 75000 lbs), 4 = Large (75000 to 300000 lbs), 5 = High Vortex Large (aircraft such as B-757), 6 = Heavy (> 300000 lbs), 7 = High Performance (> 5g acceleration and 400 kts), 8 = Rotorcraft, 9 = Glider / sailplane, 10 = Lighter-than-air, 11 = Parachutist / Skydiver, 12 = Ultralight / hang-glider / paraglider, 13 = Reserved, 14 = Unmanned Aerial Vehicle, 15 = Space / Trans-atmospheric vehicle, 16 = Surface Vehicle – Emergency Vehicle, 17 = Surface Vehicle – Service Vehicle, 18 = Point Obstacle (includes tethered balloons), 19 = Cluster Obstacle, 20 = Line Obstacle
     """
 
     keys = [
@@ -102,13 +93,11 @@ class StateVector(object):
 
 
 class OpenSkyStates(object):
-    """Represents the state of the airspace as seen by OpenSky at a particular time. It has the following fields:
+    """ Represents the state of the airspace as seen by OpenSky at a particular time. It has the following fields:
 
-    |  **time** - in seconds since epoch (Unix time stamp). Gives the validity period of all states. All vectors
-          represent the state of a vehicle with the interval :math:`[time - 1, time]`.
-    |  **states** - a list of `StateVector` or is None if there have been no states received
+      |  **time** - in seconds since epoch (Unix time stamp). Gives the validity period of all states. All vectors represent the state of a vehicle with the interval :math:`[time - 1, time]`.
+      |  **states** - a list of `StateVector` or is None if there have been no states received
     """
-
     def __init__(self, j):
         self.__dict__ = j
         if self.states is not None:
@@ -127,31 +116,27 @@ class FlightData(object):
     """
     Class that represents data of certain flight. It has the following fields:
 
-    icao24: `str`
-        Unique ICAO 24-bit address of the transponder in hex string representation. All letters are lower case.
-    firstSeen: `int`
-        Estimated time of departure for the flight as Unix time (seconds since epoch).
-    estDepartureAirport: 'str'
-        ICAO code of the estimated departure airport. Can be null if the airport could not be identified.
-    lastSeen: `int`
-        Estimated time of arrival for the flight as Unix time (seconds since epoch)
-    estArrivalAirport: `str`
-        ICAO code of the estimated arrival airport. Can be null if the airport could not be identified.
-    callsign: `str`
-        Callsign of the vehicle (8 chars). Can be null if no callsign has been received.
-         If the vehicle transmits multiple callsigns during the flight, we take the one seen most frequently
-    estDepartureAirportHorizDistance: `int`
-        Horizontal distance of the last received airborne position to the estimated departure airport in meters
-    estDepartureAirportVertDistance: `int`
-        Vertical distance of the last received airborne position to the estimated departure airport in meters
-    estArrivalAirportHorizDistance: `int`
-        Horizontal distance of the last received airborne position to the estimated arrival airport in meters
-    estArrivalAirportVertDistance: `int`
-        Vertical distance of the last received airborne position to the estimated arrival airport in meters
-    departureAirportCandidatesCount: `int`
-        Number of other possible departure airports. These are airports in short distance to estDepartureAirport.
-    arrivalAirportCandidatesCount: `int`
-        Number of other possible departure airports. These are airports in short distance to estArrivalAirport.
+    |  **icao24** - Unique ICAO 24-bit address of the transponder in hex string representation. All letters are lower case.
+    |  **firstSeen** - Estimated time of departure for the flight as Unix time (seconds since epoch).
+    |  **estDepartureAirport** - ICAO code of the estimated departure airport.
+        Can be null if the airport could not be identified.
+    |  **lastSeen** - Estimated time of arrival for the flight as Unix time (seconds since epoch).
+    |  **estArrivalAirport** - ICAO code of the estimated arrival airport.
+        Can be null if the airport could not be identified.
+    |  **callsign** - Callsign of the vehicle (8 chars). Can be null if no callsign has been received.
+        If the vehicle transmits multiple callsigns during the flight, we take the one seen most frequently.
+    |  **estDepartureAirportHorizDistance** - Horizontal distance of the last received airborne position to the
+        estimated departure airport in meters.
+    |  **estDepartureAirportVertDistance** - Vertical distance of the last received airborne position to the
+        estimated departure airport in meters.
+    |  **estArrivalAirportHorizDistance** - Horizontal distance of the last received airborne position to the
+        estimated arrival airport in meters.
+    |  **estArrivalAirportVertDistance** - Vertical distance of the last received airborne position to the
+        estimated arrival airport in meters.
+    |  **departureAirportCandidatesCount** - Number of other possible departure airports. These are airports in short
+        distance to estDepartureAirport.
+    |  **arrivalAirportCandidatesCount** - Number of other possible departure airports. These are airports in short
+        distance to estArrivalAirport.
 
     """
 
@@ -174,7 +159,7 @@ class FlightData(object):
         """
         Function that initializes the FlightData object.
 
-        :param arr: array representation of a flight data as received by the API
+        :param arr: array representation of a flight data as received by the API.
         """
         self.__dict__ = dict(zip(FlightData.keys, arr))
 
@@ -189,18 +174,12 @@ class Waypoint(object):
     """
     Class that represents the singnle waypoint that is a basic part of flight trajectory:
 
-    time: `int`
-        Time which the given waypoint is associated with in seconds since epoch (Unix time).
-    latitude: `float`
-        WGS-84 latitude in decimal degrees. Can be null.
-    longitude: 'float'
-        WGS-84 longitude in decimal degrees. Can be null.
-    baro_altitude: `float`
-        Barometric altitude in meters. Can be null.
-    true_track: `float`
-        True track in decimal degrees clockwise from north (north=0°). Can be null.
-    on_ground: `boolean`
-        Boolean value which indicates if the position was retrieved from a surface position report.
+    |  **time** - Time which the given waypoint is associated with in seconds since epoch (Unix time).
+    |  **latitude** - WGS-84 latitude in decimal degrees. Can be null.
+    |  **longitude** - WGS-84 longitude in decimal degrees. Can be null.
+    |  **baro_altitude** - Barometric altitude in meters. Can be null.
+    |  **true_track** - True track in decimal degrees clockwise from north (north=0°). Can be null.
+    |  **on_ground** - Boolean value which indicates if the position was retrieved from a surface position report.
 
     """
 
@@ -217,7 +196,7 @@ class Waypoint(object):
         """
         Function that initializes the Waypoint object.
 
-        :param arr: array representation of a single waypoint as received by the API
+        :param arr: array representation of a single waypoint as received by the API.
         """
         self.__dict__ = dict(zip(Waypoint.keys, arr))
 
@@ -232,16 +211,11 @@ class FlightTrack(object):
     """
     Class that represents the trajectory for a certain aircraft at a given time.:
 
-    icao24: `str`
-        Unique ICAO 24-bit address of the transponder in lower case hex string representation.
-    startTime: `int`
-        Time of the first waypoint in seconds since epoch (Unix time).
-    endTime: 'int'
-        Time of the last waypoint in seconds since epoch (Unix time).
-    calllsign: `string`
-        Callsign (8 characters) that holds for the whole track. Can be null.
-    path: `list`[`Waypoint`]
-        Waypoints of the trajectory (description below).
+    |  **icao24** - Unique ICAO 24-bit address of the transponder in lower case hex string representation.
+    |  **startTime** - Time of the first waypoint in seconds since epoch (Unix time).
+    |  **endTime** - Time of the last waypoint in seconds since epoch (Unix time).
+    |  **calllsign** - Callsign (8 characters) that holds for the whole track. Can be null.
+    |  **path** - waypoints of the trajectory (description below).
 
     """
 
@@ -249,7 +223,7 @@ class FlightTrack(object):
         """
         Function that initializes the FlightTrack object.
 
-        :param arr: array representation of the flight track received by the API
+        :param arr: array representation of the flight track received by the API.
 
         """
         for key, value in arr.items():
@@ -397,15 +371,12 @@ class OpenSkyApi(object):
         Retrieves data of flights for certain time interval [begin, end].
         :param begin: Start of time interval to retrieve flights for as Unix time (seconds since epoch).
         :param end: End of time interval to retrieve flights for as Unix time (seconds since epoch).
-        :return: list of FlightData objects, created based on flights from given time interval.
+        :return: list of `FlightData` objects, created based on flights from given time interval.
         """
-        if begin > end:
+        if begin >= end:
             raise ValueError("The end parameter must be greater than begin")
         if end - begin > 7200:
             raise ValueError("The time interval must be smaller than 2 hours")
-        if not self._check_rate_limit(0, 1, self.get_flighs_from_interval):
-            logger.debug("Blocking request due to rate limit")
-            return []
 
         params = {"begin": begin, "end": end}
         states_json = self._get_json(
@@ -413,8 +384,7 @@ class OpenSkyApi(object):
         )
 
         if states_json is not None:
-            flights_list = [FlightData(list(entry.values())) for entry in states_json]
-            return flights_list
+            return [FlightData(list(entry.values())) for entry in states_json]
         return []
 
     def get_flighs_by_aircraft(self, icao24: str, begin: int, end: int) -> list[FlightData]:
@@ -428,13 +398,10 @@ class OpenSkyApi(object):
 
         """
 
-        if begin > end:
+        if begin >= end:
             raise ValueError("The end parameter must be greater than begin")
         if end - begin > 2592*1e3:
             raise ValueError("The time interval must be smaller than 30 days")
-        if not self._check_rate_limit(0, 1, self.get_flighs_by_aircraft):
-            logger.debug("Blocking request due to rate limit")
-            return []
 
         params = {"icao24": icao24, "begin": begin, "end": end}
         states_json = self._get_json(
@@ -442,8 +409,7 @@ class OpenSkyApi(object):
         )
 
         if states_json is not None:
-            flights_list = [FlightData(list(entry.values())) for entry in states_json]
-            return flights_list
+            return [FlightData(list(entry.values())) for entry in states_json]
         return []
 
     def get_arrivals_by_airport(self, airport: str, begin: int, end: int) -> list[FlightData]:
@@ -455,13 +421,10 @@ class OpenSkyApi(object):
         :return: list of FlightData objects.
 
         """
-        if begin > end:
+        if begin >= end:
             raise ValueError("The end parameter must be greater than begin")
         if end - begin > 604800:
             raise ValueError("The time interval must be smaller than 7 days")
-        if not self._check_rate_limit(0, 1, self.get_arrivals_by_airport):
-            logger.debug("Blocking request due to rate limit")
-            return []
 
         params = {"airport": airport, "begin": begin, "end": end}
         states_json = self._get_json(
@@ -469,8 +432,7 @@ class OpenSkyApi(object):
         )
 
         if states_json is not None:
-            flights_list = [FlightData(list(entry.values())) for entry in states_json]
-            return flights_list
+            return [FlightData(list(entry.values())) for entry in states_json]
         return []
 
     def get_departures_by_airport(self, airport: str, begin: int, end: int) -> list[FlightData]:
@@ -482,13 +444,10 @@ class OpenSkyApi(object):
         :return: list of FlightData objects.
 
         """
-        if begin > end:
+        if begin >= end:
             raise ValueError("The end parameter must be greater than begin")
         if end - begin > 604800:
             raise ValueError("The time interval must be smaller than 7 days")
-        if not self._check_rate_limit(0, 1, self.get_departures_by_airport):
-            logger.debug("Blocking request due to rate limit")
-            return []
 
         params = {"airport": airport, "begin": begin, "end": end}
         states_json = self._get_json(
@@ -496,11 +455,10 @@ class OpenSkyApi(object):
         )
 
         if states_json is not None:
-            flights_list = [FlightData(list(entry.values())) for entry in states_json]
-            return flights_list
+            return [FlightData(list(entry.values())) for entry in states_json]
         return []
 
-    def get_track_by_aircraft(self, icao24: str, t: int = 0) -> FlightTrack:
+    def get_track_by_aircraft(self, icao24: str, t: int = 0) -> Union[FlightTrack, type(None)]:
         """
         Retrieve flights for a certain airport which arrived within a given time interval [begin, end].
         :param icao24: Unique ICAO 24-bit address of the transponder in hex string representation.
@@ -519,6 +477,5 @@ class OpenSkyApi(object):
         )
 
         if states_json is not None:
-            flight_track = FlightTrack(states_json)
-            return flight_track
-        return []
+            return FlightTrack(states_json)
+        return None

--- a/python/opensky_api.py
+++ b/python/opensky_api.py
@@ -24,46 +24,47 @@
 import calendar
 import logging
 import pprint
-import requests
-
-from datetime import datetime
-from collections import defaultdict
 import time
+from collections import defaultdict
+from datetime import datetime
+
+import requests
 
 logger = logging.getLogger("opensky_api")
 logger.addHandler(logging.NullHandler())
 
 
 class StateVector(object):
-    """ Represents the state of a vehicle at a particular time. It has the following fields:
+    """Represents the state of a vehicle at a particular time. It has the following fields:
 
-      |  **icao24**: `str` - ICAO24 address of the transmitter in hex string representation.
-      |  **callsign**: `str` - callsign of the vehicle. Can be None if no callsign has been received.
-      |  **origin_country**: `str` - inferred through the ICAO24 address
-      |  **time_position**: `int` - seconds since epoch of last position report. Can be None if there was no position report
-        received by OpenSky within 15s before.
-      |  **last_contact**: `int` - seconds since epoch of last received message from this transponder
-      |  **longitude**: `float` - in ellipsoidal coordinates (WGS-84) and degrees. Can be None
-      |  **latitude**: `float` - in ellipsoidal coordinates (WGS-84) and degrees. Can be None
-      |  **geo_altitude**: `float` - geometric altitude in meters. Can be None
-      |  **on_ground**: `bool` - true if aircraft is on ground (sends ADS-B surface position reports).
-      |  **velocity**: `float` - over ground in m/s. Can be None if information not present
-      |  **true_track**: `float` - in decimal degrees (0 is north). Can be None if information not present.
-      |  **vertical_rate**: `float` - in m/s, incline is positive, decline negative. Can be None if information not present.
-      |  **sensors**: `list` [`int`] - serial numbers of sensors which received messages from the vehicle within the validity period of
-        this state vector. Can be None if no filtering for sensor has been requested.
-      |  **baro_altitude**: `float` - barometric altitude in meters. Can be None
-      |  **squawk**: `str` - transponder code aka Squawk. Can be None
-      |  **spi**: `bool` - special purpose indicator
-      |  **position_source**: `int` - origin of this state's position: 0 = ADS-B, 1 = ASTERIX, 2 = MLAT, 3 = FLARM
-      |  **category**: `int` - aircraft category: 0 = No information at all, 1 = No ADS-B Emitter Category Information,
-        2 = Light (< 15500 lbs), 3 = Small (15500 to 75000 lbs), 4 = Large (75000 to 300000 lbs),
-        5 = High Vortex Large (aircraft such as B-757), 6 = Heavy (> 300000 lbs),
-        7 = High Performance (> 5g acceleration and 400 kts), 8 = Rotorcraft, 9 = Glider / sailplane,
-        10 = Lighter-than-air, 11 = Parachutist / Skydiver, 12 = Ultralight / hang-glider / paraglider,
-        13 = Reserved, 14 = Unmanned Aerial Vehicle, 15 = Space / Trans-atmospheric vehicle,
-        16 = Surface Vehicle – Emergency Vehicle, 17 = Surface Vehicle – Service Vehicle,
-        18 = Point Obstacle (includes tethered balloons), 19 = Cluster Obstacle, 20 = Line Obstacle
+    |  **icao24**: `str` - ICAO24 address of the transmitter in hex string representation.
+    |  **callsign**: `str` - callsign of the vehicle. Can be None if no callsign has been received.
+    |  **origin_country**: `str` - inferred through the ICAO24 address.
+    |  **time_position**: `int` - seconds since epoch of last position report. Can be None if there was no position
+      report received by OpenSky within 15s before.
+    |  **last_contact**: `int` - seconds since epoch of last received message from this transponder.
+    |  **longitude**: `float` - in ellipsoidal coordinates (WGS-84) and degrees. Can be None.
+    |  **latitude**: `float` - in ellipsoidal coordinates (WGS-84) and degrees. Can be None.
+    |  **geo_altitude**: `float` - geometric altitude in meters. Can be None.
+    |  **on_ground**: `bool` - true if aircraft is on ground (sends ADS-B surface position reports).
+    |  **velocity**: `float` - over ground in m/s. Can be None if information not present.
+    |  **true_track**: `float` - in decimal degrees (0 is north). Can be None if information not present.
+    |  **vertical_rate**: `float` - in m/s, incline is positive, decline negative. Can be None if information not
+      present.
+    |  **sensors**: `list` [`int`] - serial numbers of sensors which received messages from the vehicle within
+      the validity period of this state vector. Can be None if no filtering for sensor has been requested.
+    |  **baro_altitude**: `float` - barometric altitude in meters. Can be None.
+    |  **squawk**: `str` - transponder code aka Squawk. Can be None.
+    |  **spi**: `bool` - special purpose indicator.
+    |  **position_source**: `int` - origin of this state's position: 0 = ADS-B, 1 = ASTERIX, 2 = MLAT, 3 = FLARM
+    |  **category**: `int` - aircraft category: 0 = No information at all, 1 = No ADS-B Emitter Category Information,
+      2 = Light (< 15500 lbs), 3 = Small (15500 to 75000 lbs), 4 = Large (75000 to 300000 lbs),
+      5 = High Vortex Large (aircraft such as B-757), 6 = Heavy (> 300000 lbs),
+      7 = High Performance (> 5g acceleration and 400 kts), 8 = Rotorcraft, 9 = Glider / sailplane,
+      10 = Lighter-than-air, 11 = Parachutist / Skydiver, 12 = Ultralight / hang-glider / paraglider,
+      13 = Reserved, 14 = Unmanned Aerial Vehicle, 15 = Space / Trans-atmospheric vehicle,
+      16 = Surface Vehicle – Emergency Vehicle, 17 = Surface Vehicle – Service Vehicle,
+      18 = Point Obstacle (includes tethered balloons), 19 = Cluster Obstacle, 20 = Line Obstacle.
     """
 
     keys = [
@@ -92,7 +93,8 @@ class StateVector(object):
     def __init__(self, arr):
         """
         Initializes the StateVector object.
-        :param list arr: the array representation of a state vector as received by the API
+
+        :param list arr: the array representation of a state vector as received by the API.
         """
         self.__dict__ = dict(zip(StateVector.keys, arr))
 
@@ -104,18 +106,21 @@ class StateVector(object):
 
 
 class OpenSkyStates(object):
-    """ Represents the state of the airspace as seen by OpenSky at a particular time. It has the following fields:
+    """Represents the state of the airspace as seen by OpenSky at a particular time. It has the following fields:
 
-      |  **time**: `int` - in seconds since epoch (Unix time stamp). Gives the validity period of all states.
-        All vectors represent the state of a vehicle with the interval :math:`[time - 1, time]`.
-      |  **states**: `list` [`StateVector`] - a list of `StateVector` or is None if there have been no states received
+    |  **time**: `int` - in seconds since epoch (Unix time stamp). Gives the validity period of all states.
+      All vectors represent the state of a vehicle with the interval :math:`[time - 1, time]`.
+    |  **states**: `list` [`StateVector`] - a list of `StateVector` or is None if there have been no states received.
     """
-    def __init__(self, j):
+
+    def __init__(self, states_dict):
         """
-        Initializes the OpenSkyStates object
-        :param dict j: the json represents the state of the airspace as seen by OpenSky at a particular time
+        Initializes the OpenSkyStates object.
+
+        :param dict states_dict: the dictionary that represents the state of the airspace as seen by OpenSky
+            at a particular time.
         """
-        self.__dict__ = j
+        self.__dict__ = states_dict
         if self.states is not None:
             self.states = [StateVector(a) for a in self.states]
         else:
@@ -150,10 +155,10 @@ class FlightData(object):
         estimated arrival airport in meters.
     |  **estArrivalAirportVertDistance**: `int` - Vertical distance of the last received airborne position to the
         estimated arrival airport in meters.
-    |  **departureAirportCandidatesCount**: `int` - Number of other possible departure airports. These are airports in short
-        distance to estDepartureAirport.
-    |  **arrivalAirportCandidatesCount**: `int` - Number of other possible departure airports. These are airports in short
-        distance to estArrivalAirport.
+    |  **departureAirportCandidatesCount**: `int` - Number of other possible departure airports.
+        These are airports in short distance to estDepartureAirport.
+    |  **arrivalAirportCandidatesCount**: `int` - Number of other possible departure airports.
+    These are airports in short distance to estArrivalAirport.
     """
 
     keys = [
@@ -188,14 +193,15 @@ class FlightData(object):
 
 class Waypoint(object):
     """
-    Class that represents the singnle waypoint that is a basic part of flight trajectory:
+    Class that represents the single waypoint that is a basic part of flight trajectory:
 
     |  **time**: `int` - Time which the given waypoint is associated with in seconds since epoch (Unix time).
     |  **latitude**: `float` - WGS-84 latitude in decimal degrees. Can be null.
     |  **longitude**: `float` - WGS-84 longitude in decimal degrees. Can be null.
     |  **baro_altitude**: `float` - Barometric altitude in meters. Can be null.
     |  **true_track**: `float` - True track in decimal degrees clockwise from north (north=0°). Can be null.
-    |  **on_ground**: `bool` - Boolean value which indicates if the position was retrieved from a surface position report.
+    |  **on_ground**: `bool` - Boolean value which indicates if the position was retrieved from a surface
+        position report.
     """
 
     keys = [
@@ -253,15 +259,15 @@ class FlightTrack(object):
 
 class OpenSkyApi(object):
     """
-    Main class of the OpenSky Network API. Instances retrieve data from OpenSky via HTTP
+    Main class of the OpenSky Network API. Instances retrieve data from OpenSky via HTTP.
     """
 
     def __init__(self, username=None, password=None):
         """Create an instance of the API client. If you do not provide username and password requests will be
         anonymous which imposes some limitations.
 
-        :param str username: an OpenSky username (optional)
-        :param str password: an OpenSky password for the given username (optional)
+        :param str username: an OpenSky username (optional).
+        :param str password: an OpenSky password for the given username (optional).
         """
         if username is not None:
             self._auth = (username, password)
@@ -272,11 +278,11 @@ class OpenSkyApi(object):
 
     def _get_json(self, url_post, callee, params=None):
         """
-        Sends HTTP request to the given endpoint and returns the response as a json
+        Sends HTTP request to the given endpoint and returns the response as a json.
 
-        :param str url_post: endpoint to which the request will be sent
-        :param Callable callee: method that calls _get_json()
-        :param dict params: request parameters
+        :param str url_post: endpoint to which the request will be sent.
+        :param Callable callee: method that calls _get_json().
+        :param dict params: request parameters.
         :rtype: dict|None
         """
         r = requests.get(
@@ -296,11 +302,11 @@ class OpenSkyApi(object):
 
     def _check_rate_limit(self, time_diff_noauth, time_diff_auth, func):
         """
-        Impose client-side rate limit
+        Impose client-side rate limit.
 
-        :param int time_diff_noauth: the minimum time between two requests in seconds if not using authentication
-        :param int time_diff_auth: the minimum time between two requests in seconds if using authentication
-        :param callable func: the API function to evaluate
+        :param int time_diff_noauth: the minimum time between two requests in seconds if not using authentication.
+        :param int time_diff_auth: the minimum time between two requests in seconds if using authentication.
+        :param callable func: the API function to evaluate.
         :rtype: bool
         """
         if len(self._auth) < 2:
@@ -311,13 +317,13 @@ class OpenSkyApi(object):
     @staticmethod
     def _check_lat(lat):
         if lat < -90 or lat > 90:
-            raise ValueError("Invalid latitude {:f}! Must be in [-90, 90]".format(lat))
+            raise ValueError("Invalid latitude {:f}! Must be in [-90, 90].".format(lat))
 
     @staticmethod
     def _check_lon(lon):
         if lon < -180 or lon > 180:
             raise ValueError(
-                "Invalid longitude {:f}! Must be in [-180, 180]".format(lon)
+                "Invalid longitude {:f}! Must be in [-180, 180].".format(lon)
             )
 
     def get_states(self, time_secs=0, icao24=None, bbox=()):
@@ -327,15 +333,15 @@ class OpenSkyApi(object):
 
         :param int time_secs: time as Unix time stamp (seconds since epoch) or datetime. The datetime must be in UTC!
         :param str icao24: optionally retrieve only state vectors for the given ICAO24 address(es).
-            The parameter can either be a single address as str or an array of str containing multiple addresses
+            The parameter can either be a single address as str or an array of str containing multiple addresses.
         :param tuple bbox: optionally retrieve state vectors within a bounding box.
             The bbox must be a tuple of exactly four values [min_latitude, max_latitude, min_longitude, max_longitude]
             each in WGS84 decimal degrees.
-        :return: OpenSkyStates if request was successful, None otherwise
+        :return: OpenSkyStates if request was successful, None otherwise.
         :rtype: OpenSkyStates | None
         """
         if not self._check_rate_limit(10, 5, self.get_states):
-            logger.debug("Blocking request due to rate limit")
+            logger.debug("Blocking request due to rate limit.")
             return None
 
         t = time_secs
@@ -356,7 +362,7 @@ class OpenSkyApi(object):
             params["lomax"] = bbox[3]
         elif len(bbox) > 0:
             raise ValueError(
-                "Invalid bounding box! Must be [min_latitude, max_latitude, min_longitude, max_longitude]"
+                "Invalid bounding box! Must be [min_latitude, max_latitude, min_longitude, max_longitude]."
             )
 
         states_json = self._get_json("/states/all", self.get_states, params=params)
@@ -372,16 +378,16 @@ class OpenSkyApi(object):
 
         :param int time_secs: time as Unix time stamp (seconds since epoch) or datetime. The datetime must be in UTC!
         :param str icao24: optionally retrieve only state vectors for the given ICAO24 address(es).
-            The parameter can either be a single address as str or an array of str containing multiple addresses
+            The parameter can either be a single address as str or an array of str containing multiple addresses.
         :param int serials: optionally retrieve only states of vehicles as seen by the given sensor(s).
             The parameter can either be a single sensor serial number (int) or a list of serial numbers.
-        :return: OpenSkyStates if request was successful, None otherwise
+        :return: OpenSkyStates if request was successful, None otherwise.
         :rtype: OpenSkyStates | None
         """
         if len(self._auth) < 2:
             raise Exception("No username and password provided for get_my_states!")
         if not self._check_rate_limit(0, 1, self.get_my_states):
-            logger.debug("Blocking request due to rate limit")
+            logger.debug("Blocking request due to rate limit.")
             return None
         t = time_secs
         if type(time_secs) == datetime:
@@ -408,9 +414,9 @@ class OpenSkyApi(object):
         :rtype: FlightData | None
         """
         if begin >= end:
-            raise ValueError("The end parameter must be greater than begin")
+            raise ValueError("The end parameter must be greater than begin.")
         if end - begin > 7200:
-            raise ValueError("The time interval must be smaller than 2 hours")
+            raise ValueError("The time interval must be smaller than 2 hours.")
 
         params = {"begin": begin, "end": end}
         states_json = self._get_json(
@@ -426,7 +432,7 @@ class OpenSkyApi(object):
         Retrieves data of flights for certain aircraft and time interval.
 
         :param str icao24: Unique ICAO 24-bit address of the transponder in hex string representation.
-            All letters need to be lower case
+            All letters need to be lower case.
         :param int begin: Start of time interval to retrieve flights for as Unix time (seconds since epoch).
         :param int end: End of time interval to retrieve flights for as Unix time (seconds since epoch).
         :return: list of FlightData objects if request was successful, None otherwise.
@@ -434,9 +440,9 @@ class OpenSkyApi(object):
         """
 
         if begin >= end:
-            raise ValueError("The end parameter must be greater than begin")
-        if end - begin > 2592*1e3:
-            raise ValueError("The time interval must be smaller than 30 days")
+            raise ValueError("The end parameter must be greater than begin.")
+        if end - begin > 2592 * 1e3:
+            raise ValueError("The time interval must be smaller than 30 days.")
 
         params = {"icao24": icao24, "begin": begin, "end": end}
         states_json = self._get_json(
@@ -451,16 +457,16 @@ class OpenSkyApi(object):
         """
         Retrieves flights for a certain airport which arrived within a given time interval [begin, end].
 
-        :param str airport: ICAO identier for the airport
-        :param int begin: Start of time interval to retrieve flights for as Unix time (seconds since epoch)
-        :param int end: End of time interval to retrieve flights for as Unix time (seconds since epoch)
-        :return: list of FlightData objects if request was successful, None otherwise.
+        :param str airport: ICAO identier for the airport.
+        :param int begin: Start of time interval to retrieve flights for as Unix time (seconds since epoch).
+        :param int end: End of time interval to retrieve flights for as Unix time (seconds since epoch).
+        :return: list of FlightData objects if request was successful, None otherwise..
         :rtype: FlightData | None
         """
         if begin >= end:
-            raise ValueError("The end parameter must be greater than begin")
+            raise ValueError("The end parameter must be greater than begin.")
         if end - begin > 604800:
-            raise ValueError("The time interval must be smaller than 7 days")
+            raise ValueError("The time interval must be smaller than 7 days.")
 
         params = {"airport": airport, "begin": begin, "end": end}
         states_json = self._get_json(
@@ -475,16 +481,16 @@ class OpenSkyApi(object):
         """
         Retrieves flights for a certain airport which arrived within a given time interval [begin, end].
 
-        :param str airport: ICAO identier for the airport
-        :param int begin: Start of time interval to retrieve flights for as Unix time (seconds since epoch)
-        :param int end: End of time interval to retrieve flights for as Unix time (seconds since epoch)
+        :param str airport: ICAO identier for the airport.
+        :param int begin: Start of time interval to retrieve flights for as Unix time (seconds since epoch).
+        :param int end: End of time interval to retrieve flights for as Unix time (seconds since epoch).
         :return: list of FlightData objects if request was successful, None otherwise.
         :rtype: FlightData | None
         """
         if begin >= end:
-            raise ValueError("The end parameter must be greater than begin")
+            raise ValueError("The end parameter must be greater than begin.")
         if end - begin > 604800:
-            raise ValueError("The time interval must be smaller than 7 days")
+            raise ValueError("The time interval must be smaller than 7 days.")
 
         params = {"airport": airport, "begin": begin, "end": end}
         states_json = self._get_json(
@@ -501,14 +507,16 @@ class OpenSkyApi(object):
         **The tracks endpoint is purely experimental.**
 
         :param str icao24: Unique ICAO 24-bit address of the transponder in hex string representation.
-            All letters need to be lower case
+            All letters need to be lower case.
         :param int t: Unix time in seconds since epoch. It can be any time between start and end of a known flight.
             If time = 0, get the live track if there is any flight ongoing for the given aircraft.
         :return: FlightTrack object if request was successful, None otherwise.
         :rtype: FlightTrack | None
         """
-        if int(time.time()) - t > 2592*1e3 and t != 0:
-            raise ValueError("It is not possible to access flight tracks from more than 30 days in the past.")
+        if int(time.time()) - t > 2592 * 1e3 and t != 0:
+            raise ValueError(
+                "It is not possible to access flight tracks from more than 30 days in the past."
+            )
 
         params = {"icao24": icao24, "time": t}
         states_json = self._get_json(

--- a/python/test_opensky_api.py
+++ b/python/test_opensky_api.py
@@ -25,7 +25,7 @@ import time
 from datetime import datetime
 from unittest import TestCase, skipIf
 
-from opensky_api import OpenSkyApi, StateVector, FlightData, Waypoint, FlightTrack
+from opensky_api import FlightData, FlightTrack, OpenSkyApi, StateVector, Waypoint
 
 # Add your username, password and at least one sensor
 # to run all tests
@@ -81,7 +81,28 @@ class TestOpenSkyApi(TestCase):
             self.api.get_states(bbox=(45.8389, 47.8229, 5.9962, 210.5226))
 
     def test_state_vector_parsing(self):
-        s = StateVector(["cabeef","ABCDEFG","USA",1001,1000,1.0,2.0,3.0,False,4.0,5.0,6.0,None,6743.7,"6714",False,0,0])
+        s = StateVector(
+            [
+                "cabeef",
+                "ABCDEFG",
+                "USA",
+                1001,
+                1000,
+                1.0,
+                2.0,
+                3.0,
+                False,
+                4.0,
+                5.0,
+                6.0,
+                None,
+                6743.7,
+                "6714",
+                False,
+                0,
+                0,
+            ]
+        )
         self.assertEqual("cabeef", s.icao24)
         self.assertEqual("ABCDEFG", s.callsign)
         self.assertEqual("USA", s.origin_country)
@@ -116,7 +137,20 @@ class TestOpenSkyApi(TestCase):
             "departureAirportCandidatesCount",
             "arrivalAirportCandidatesCount",
         ]
-        values = ['4951d0', 1517230550, 'EDDF', 1517240237, 'LPCS', 'TAP583  ', 3808, 80, 14016, 708, 2, 3]
+        values = [
+            "4951d0",
+            1517230550,
+            "EDDF",
+            1517240237,
+            "LPCS",
+            "TAP583  ",
+            3808,
+            80,
+            14016,
+            708,
+            2,
+            3,
+        ]
         f = FlightData(values)
         for key, exp_val in zip(keys, values):
             self.assertEqual(exp_val, getattr(f, key))
@@ -130,27 +164,27 @@ class TestOpenSkyApi(TestCase):
             "true_track",
             "on_ground",
         ]
-        values = [1675450754, 39.0912, -94.5794, 304, 91, False]
+        values = [1675450754, 39.0912, -94.5794, 304.0, 91.0, False]
         w = Waypoint(values)
         for key, exp_val in zip(keys, values):
             self.assertEqual(exp_val, getattr(w, key))
 
     def test_flight_track_parsing(self):
-        entry = {'icao24': 'a01391',
-                 'callsign': 'N104AA  ',
-                 'startTime': 1675450754.0,
-                 'endTime': 1675451752.0,
-                 'path':
-                     [
-                         [1675450754, 39.0912, -94.5794, 304, 91, False],
-                         [1675450768, 39.0916, -94.5717, 304, 65, False],
-                         [1675450776, 39.0936, -94.5687, 304, 33, False],
-                         [1675450776, 39.0936, -94.5687, 304, 8, False],
-                         [1675451134, 39.1073, -94.613, 304, 296, False],
-                         [1675451134, 39.1073, -94.613, 304, 292, False],
-                         [1675451752, 39.1056, -94.6143, 304, 287, False]
-                     ]
-                 }
+        entry = {
+            "icao24": "a01391",
+            "callsign": "N104AA  ",
+            "startTime": 1675450754,
+            "endTime": 1675451752,
+            "path": [
+                [1675450754, 39.0912, -94.5794, 304.0, 91.0, False],
+                [1675450768, 39.0916, -94.5717, 304.0, 65.0, False],
+                [1675450776, 39.0936, -94.5687, 304.0, 33.0, False],
+                [1675450776, 39.0936, -94.5687, 304.0, 8.0, False],
+                [1675451134, 39.1073, -94.613, 304.0, 296.0, False],
+                [1675451134, 39.1073, -94.613, 304.0, 292.0, False],
+                [1675451752, 39.1056, -94.6143, 304.0, 287.0, False],
+            ],
+        }
 
         f = FlightTrack(entry)
         for key, exp_val in entry.items():
@@ -158,7 +192,9 @@ class TestOpenSkyApi(TestCase):
 
     def test_get_my_states_no_auth(self):
         a = OpenSkyApi()
-        with self.assertRaisesRegex(Exception, "No username and password provided for get_my_states!"):
+        with self.assertRaisesRegex(
+            Exception, "No username and password provided for get_my_states!"
+        ):
             a.get_my_states()
 
     @skipIf(len(TEST_USERNAME) < 1, "Missing credentials")
@@ -193,11 +229,15 @@ class TestOpenSkyApi(TestCase):
         self.assertGreater(len(r), 0, "Retrieve at least one State Vector")
 
     def test_get_flights_from_interval_reversed_timestamps(self):
-        with self.assertRaisesRegex(Exception, "The end parameter must be greater than begin"):
+        with self.assertRaisesRegex(
+            Exception, "The end parameter must be greater than begin"
+        ):
             r = self.api.get_flights_from_interval(1517230800, 1517227200)
 
     def test_get_flights_from_interval_too_long_time_interval(self):
-        with self.assertRaisesRegex(Exception, "The time interval must be smaller than 2 hours"):
+        with self.assertRaisesRegex(
+            Exception, "The time interval must be smaller than 2 hours"
+        ):
             r = self.api.get_flights_from_interval(1517227200, 1517234401)
 
     def test_get_flights_by_aircraft(self):
@@ -205,11 +245,15 @@ class TestOpenSkyApi(TestCase):
         self.assertGreater(len(r), 0, "Retrieve at least one State Vector")
 
     def test_get_flights_by_aircraft_reversed_timestamps(self):
-        with self.assertRaisesRegex(Exception, "The end parameter must be greater than begin"):
+        with self.assertRaisesRegex(
+            Exception, "The end parameter must be greater than begin"
+        ):
             r = self.api.get_flights_by_aircraft("3c675a", 1517270400, 1517184000)
 
     def test_get_flights_by_aircraft_too_long_time_interval(self):
-        with self.assertRaisesRegex(Exception, "The time interval must be smaller than 30 days"):
+        with self.assertRaisesRegex(
+            Exception, "The time interval must be smaller than 30 days"
+        ):
             r = self.api.get_flights_by_aircraft("3c675a", 1517184000, 1519776001)
 
     def test_get_arrivals_by_airport(self):
@@ -217,11 +261,15 @@ class TestOpenSkyApi(TestCase):
         self.assertGreater(len(r), 0, "Retrieve at least one State Vector")
 
     def test_get_arrivals_by_airport_reversed_timestamps(self):
-        with self.assertRaisesRegex(Exception, "The end parameter must be greater than begin"):
+        with self.assertRaisesRegex(
+            Exception, "The end parameter must be greater than begin"
+        ):
             r = self.api.get_arrivals_by_airport("EDDF", 1517230800, 1517227200)
 
     def test_get_arrivals_by_airport_too_long_time_interval(self):
-        with self.assertRaisesRegex(Exception, "The time interval must be smaller than 7 days"):
+        with self.assertRaisesRegex(
+            Exception, "The time interval must be smaller than 7 days"
+        ):
             r = self.api.get_arrivals_by_airport("EDDF", 1517227200, 1517832001)
 
     def test_get_departures_by_airport(self):
@@ -229,9 +277,13 @@ class TestOpenSkyApi(TestCase):
         self.assertGreater(len(r), 0, "Retrieve at least one State Vector")
 
     def test_get_departures_by_airport_reversed_timestamps(self):
-        with self.assertRaisesRegex(Exception, "The end parameter must be greater than begin"):
+        with self.assertRaisesRegex(
+            Exception, "The end parameter must be greater than begin"
+        ):
             r = self.api.get_departures_by_airport("EDDF", 1517230800, 1517227200)
 
     def test_get_departures_by_airport_too_long_time_interval(self):
-        with self.assertRaisesRegex(Exception, "The time interval must be smaller than 7 days"):
+        with self.assertRaisesRegex(
+            Exception, "The time interval must be smaller than 7 days"
+        ):
             r = self.api.get_departures_by_airport("EDDF", 1517227200, 1517832001)

--- a/python/test_opensky_api.py
+++ b/python/test_opensky_api.py
@@ -25,7 +25,7 @@ import time
 from datetime import datetime
 from unittest import TestCase, skipIf
 
-from opensky_api import OpenSkyApi, StateVector
+from opensky_api import OpenSkyApi, StateVector, FlightData, Waypoint, FlightTrack
 
 # Add your username, password and at least one sensor
 # to run all tests
@@ -101,6 +101,61 @@ class TestOpenSkyApi(TestCase):
         self.assertEqual(0, s.position_source)
         self.assertEqual(0, s.category)
 
+    def test_flight_data_parsing(self):
+        keys = [
+            "icao24",
+            "firstSeen",
+            "estDepartureAirport",
+            "lastSeen",
+            "estArrivalAirport",
+            "callsign",
+            "estDepartureAirportHorizDistance",
+            "estDepartureAirportVertDistance",
+            "estArrivalAirportHorizDistance",
+            "estArrivalAirportVertDistance",
+            "departureAirportCandidatesCount",
+            "arrivalAirportCandidatesCount",
+        ]
+        values = ['4951d0', 1517230550, 'EDDF', 1517240237, 'LPCS', 'TAP583  ', 3808, 80, 14016, 708, 2, 3]
+        f = FlightData(values)
+        for key, exp_val in zip(keys, values):
+            self.assertEqual(exp_val, getattr(f, key))
+
+    def test_waypoint_parsing(self):
+        keys = [
+            "time",
+            "latitude",
+            "longitude",
+            "baro_altitude",
+            "true_track",
+            "on_ground",
+        ]
+        values = [1675450754, 39.0912, -94.5794, 304, 91, False]
+        w = Waypoint(values)
+        for key, exp_val in zip(keys, values):
+            self.assertEqual(exp_val, getattr(w, key))
+
+    def test_flight_track_parsing(self):
+        entry = {'icao24': 'a01391',
+                 'callsign': 'N104AA  ',
+                 'startTime': 1675450754.0,
+                 'endTime': 1675451752.0,
+                 'path':
+                     [
+                         [1675450754, 39.0912, -94.5794, 304, 91, False],
+                         [1675450768, 39.0916, -94.5717, 304, 65, False],
+                         [1675450776, 39.0936, -94.5687, 304, 33, False],
+                         [1675450776, 39.0936, -94.5687, 304, 8, False],
+                         [1675451134, 39.1073, -94.613, 304, 296, False],
+                         [1675451134, 39.1073, -94.613, 304, 292, False],
+                         [1675451752, 39.1056, -94.6143, 304, 287, False]
+                     ]
+                 }
+
+        f = FlightTrack(entry)
+        for key, exp_val in entry.items():
+            self.assertEqual(exp_val, getattr(f, key))
+
     def test_get_my_states_no_auth(self):
         a = OpenSkyApi()
         with self.assertRaisesRegex(Exception, "No username and password provided for get_my_states!"):
@@ -132,3 +187,51 @@ class TestOpenSkyApi(TestCase):
         self.assertGreater(len(r.states), 0, "Retrieve at least one State Vector")
         r = self.api.get_my_states()
         self.assertIsNone(r, "Rate limit produces 'None' result")
+
+    def test_get_flights_from_interval(self):
+        r = self.api.get_flighs_from_interval(1517227200, 1517230800)
+        self.assertGreater(len(r), 0, "Retrieve at least one State Vector")
+
+    def test_get_flights_from_interval_reversed_timestamps(self):
+        with self.assertRaisesRegex(Exception, "The end parameter must be greater than begin"):
+            r = self.api.get_flighs_from_interval(1517230800, 1517227200)
+
+    def test_get_flights_from_interval_too_long_time_interval(self):
+        with self.assertRaisesRegex(Exception, "The time interval must be smaller than 2 hours"):
+            r = self.api.get_flighs_from_interval(1517227200, 1517234401)
+
+    def test_get_flighs_by_aircraft(self):
+        r = self.api.get_flighs_by_aircraft("3c675a", 1517184000, 1517270400)
+        self.assertGreater(len(r), 0, "Retrieve at least one State Vector")
+
+    def test_get_flighs_by_aircraft_reversed_timestamps(self):
+        with self.assertRaisesRegex(Exception, "The end parameter must be greater than begin"):
+            r = self.api.get_flighs_by_aircraft("3c675a", 1517270400, 1517184000)
+
+    def test_get_flighs_by_aircraft_too_long_time_interval(self):
+        with self.assertRaisesRegex(Exception, "The time interval must be smaller than 30 days"):
+            r = self.api.get_flighs_by_aircraft("3c675a", 1517184000, 1519776001)
+
+    def test_get_arrivals_by_airport(self):
+        r = self.api.get_arrivals_by_airport("EDDF", 1517227200, 1517230800)
+        self.assertGreater(len(r), 0, "Retrieve at least one State Vector")
+
+    def test_get_arrivals_by_airport_reversed_timestamps(self):
+        with self.assertRaisesRegex(Exception, "The end parameter must be greater than begin"):
+            r = self.api.get_arrivals_by_airport("EDDF", 1517230800, 1517227200)
+
+    def test_get_arrivals_by_airport_too_long_time_interval(self):
+        with self.assertRaisesRegex(Exception, "The time interval must be smaller than 7 days"):
+            r = self.api.get_arrivals_by_airport("EDDF", 1517227200, 1517832001)
+
+    def test_get_departures_by_airport(self):
+        r = self.api.get_departures_by_airport("EDDF", 1517227200, 1517230800)
+        self.assertGreater(len(r), 0, "Retrieve at least one State Vector")
+
+    def test_get_departures_by_airport_reversed_timestamps(self):
+        with self.assertRaisesRegex(Exception, "The end parameter must be greater than begin"):
+            r = self.api.get_departures_by_airport("EDDF", 1517230800, 1517227200)
+
+    def test_get_departures_by_airport_too_long_time_interval(self):
+        with self.assertRaisesRegex(Exception, "The time interval must be smaller than 7 days"):
+            r = self.api.get_departures_by_airport("EDDF", 1517227200, 1517832001)

--- a/python/test_opensky_api.py
+++ b/python/test_opensky_api.py
@@ -189,28 +189,28 @@ class TestOpenSkyApi(TestCase):
         self.assertIsNone(r, "Rate limit produces 'None' result")
 
     def test_get_flights_from_interval(self):
-        r = self.api.get_flighs_from_interval(1517227200, 1517230800)
+        r = self.api.get_flights_from_interval(1517227200, 1517230800)
         self.assertGreater(len(r), 0, "Retrieve at least one State Vector")
 
     def test_get_flights_from_interval_reversed_timestamps(self):
         with self.assertRaisesRegex(Exception, "The end parameter must be greater than begin"):
-            r = self.api.get_flighs_from_interval(1517230800, 1517227200)
+            r = self.api.get_flights_from_interval(1517230800, 1517227200)
 
     def test_get_flights_from_interval_too_long_time_interval(self):
         with self.assertRaisesRegex(Exception, "The time interval must be smaller than 2 hours"):
-            r = self.api.get_flighs_from_interval(1517227200, 1517234401)
+            r = self.api.get_flights_from_interval(1517227200, 1517234401)
 
-    def test_get_flighs_by_aircraft(self):
-        r = self.api.get_flighs_by_aircraft("3c675a", 1517184000, 1517270400)
+    def test_get_flights_by_aircraft(self):
+        r = self.api.get_flights_by_aircraft("3c675a", 1517184000, 1517270400)
         self.assertGreater(len(r), 0, "Retrieve at least one State Vector")
 
-    def test_get_flighs_by_aircraft_reversed_timestamps(self):
+    def test_get_flights_by_aircraft_reversed_timestamps(self):
         with self.assertRaisesRegex(Exception, "The end parameter must be greater than begin"):
-            r = self.api.get_flighs_by_aircraft("3c675a", 1517270400, 1517184000)
+            r = self.api.get_flights_by_aircraft("3c675a", 1517270400, 1517184000)
 
-    def test_get_flighs_by_aircraft_too_long_time_interval(self):
+    def test_get_flights_by_aircraft_too_long_time_interval(self):
         with self.assertRaisesRegex(Exception, "The time interval must be smaller than 30 days"):
-            r = self.api.get_flighs_by_aircraft("3c675a", 1517184000, 1519776001)
+            r = self.api.get_flights_by_aircraft("3c675a", 1517184000, 1519776001)
 
     def test_get_arrivals_by_airport(self):
         r = self.api.get_arrivals_by_airport("EDDF", 1517227200, 1517230800)


### PR DESCRIPTION
I recently found the OpenSky service, and it's great! I used it in my private data analysis projects. So far I have mainly worked with the REST API, but decided to adapt the python library to all request types that were needed. During the work, the code has been tested on Python 3.10 and 2.7 to keep compatibility, as assumed.
I'm happy to contribute to this project!

The scope of changes is the extension of the `OpenSkyApi` class with additional methods, that cover all types of requests available in the OpenSky REST API.