### PR TITLE
Update opensky_api.py

### DIFF
--- a/python/opensky_api.py
+++ b/python/opensky_api.py
@@ -157,8 +157,8 @@ class FlightData(object):
         estimated arrival airport in meters.
     |  **departureAirportCandidatesCount**: `int` - Number of other possible departure airports.
         These are airports in short distance to estDepartureAirport.
-    |  **arrivalAirportCandidatesCount**: `int` - Number of other possible departure airports.
-    These are airports in short distance to estArrivalAirport.
+    |  **arrivalAirportCandidatesCount**: `int` - Number of other possible arrival airports.
+        These are airports in short distance to estArrivalAirport.
     """
 
     keys = [


### PR DESCRIPTION
Small mistake in documentation?
It says: 
"arrivalAirportCandidatesCount: int - Number of other possible departure airports." And I think it should say:
"arrivalAirportCandidatesCount: int - Number of other possible arrival airports." Moreover, the line is badly separated.