### PR TITLE
 Adding support for OAuth2 Client Credentials Flow + dependency upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ will output something like this:
 
 ## Java API
 
-* Maven project (not yet in a public repository)
+* Maven project (not yet in a public repository). Clone this repo and build locally (see installation instructions below).
 * Uses [```OkHttp```](https://square.github.io/okhttp/) for HTTP requests
 
 ### Installation
@@ -65,7 +65,7 @@ Add the following dependency to your project
 <dependency>
     <groupId>org.opensky</groupId>
     <artifactId>opensky-api</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ Add the following dependency to your project
 
 ### Usage
 
+With OAuth clientId / clientSecret:
+```
+OpenSkyApi api = new OpenSkyApi("clientId", "clientSecret", true);
+    OpenSkyStates os = api.getStates(0, null,
+            new OpenSkyApi.BoundingBox(45.8389, 47.8229, 5.9962, 10.5226));
+
+    os.getStates().forEach(System.out::println);
+```
+
+Unauthenticated:
 ```
 OpenSkyStates states = new OpenSkyApi().getStates(0);
 System.out.println("Number of states: " + states.getStates().size());
@@ -85,7 +95,7 @@ In build.gradle, add the following lines
 
     dependencies {
         /* do not delete the other entries, just add this one */
-        compile 'org.opensky:opensky-api:1.3.0'
+        compile 'org.opensky:opensky-api:1.4.0'
     }
 
     repositories {

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -6,22 +6,23 @@
 
     <groupId>org.opensky</groupId>
     <artifactId>opensky-api</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.13.0</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <release>17</release>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -34,7 +35,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.10.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -86,19 +87,18 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>3.6.0</version>
+            <version>4.12.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.7.1</version>
+            <version>2.18.2</version>
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
-            <scope>test</scope>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.11.4</version>
         </dependency>
 
     </dependencies>

--- a/java/src/main/java/org/opensky/api/Authentication.java
+++ b/java/src/main/java/org/opensky/api/Authentication.java
@@ -1,0 +1,65 @@
+package org.opensky.api;
+
+import okhttp3.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.io.IOException;
+
+/**
+ * The Authentication class is responsible for handling authentication
+ * requests to retrieve an access token from the OpenSky Network's authentication API.
+ */
+public class Authentication {
+
+    /**
+     * The API endpoint for retrieving an access token from the OpenSky Network's authentication system.
+     * This URL is used to send authentication requests with client credentials to obtain access tokens.
+     */
+    private static final String TOKEN_API =
+            "https://auth.opensky-network.org/auth/realms/opensky-network/protocol/openid-connect/token";
+
+    /**
+     * Retrieves an access token from the authentication API using the provided client credentials.
+     *
+     * @param clientId the client identifier to authenticate with the API
+     * @param clientSecret the client secret associated with the client identifier
+     * @return the access token as a string
+     * @throws RuntimeException if the token retrieval fails or an I/O error occurs
+     */
+    public String accessToken(String clientId, String clientSecret) {
+        // Create the OkHttpClient instance
+        OkHttpClient client = new OkHttpClient();
+
+        // Build the request body with the required parameters
+        RequestBody requestBody = new FormBody.Builder()
+                .add("grant_type", "client_credentials")
+                .add("client_id", clientId)
+                .add("client_secret", clientSecret)
+                .build();
+
+        // Create the POST request
+        Request request = new Request.Builder()
+                .url(TOKEN_API)
+                .post(requestBody)
+                .addHeader("Content-Type", "application/x-www-form-urlencoded")
+                .build();
+
+        // Execute the request
+        try (Response response = client.newCall(request).execute()) {
+            if (response.isSuccessful() && response.body() != null) {
+                String responseBody = response.body().string();
+                ObjectMapper mapper = new ObjectMapper();
+                JsonNode jsonNode = mapper.readTree(responseBody);
+                String accessToken = jsonNode.get("access_token").asText();
+                //System.out.println("Access Token: " + accessToken);
+                return accessToken;
+            } else {
+                throw new RuntimeException("Failed to fetch access token. Response: " + response);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+}

--- a/java/src/main/java/org/opensky/api/OpenSkyAuthentication.java
+++ b/java/src/main/java/org/opensky/api/OpenSkyAuthentication.java
@@ -10,7 +10,14 @@ import java.io.IOException;
  * The Authentication class is responsible for handling authentication
  * requests to retrieve an access token from the OpenSky Network's authentication API.
  */
-public class Authentication {
+public class OpenSkyAuthentication {
+    private final String clientId;
+    private final String clientSecret;
+
+    public OpenSkyAuthentication(String clientId, String clientSecret) {
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+    }
 
     /**
      * The API endpoint for retrieving an access token from the OpenSky Network's authentication system.
@@ -19,15 +26,8 @@ public class Authentication {
     private static final String TOKEN_API =
             "https://auth.opensky-network.org/auth/realms/opensky-network/protocol/openid-connect/token";
 
-    /**
-     * Retrieves an access token from the authentication API using the provided client credentials.
-     *
-     * @param clientId the client identifier to authenticate with the API
-     * @param clientSecret the client secret associated with the client identifier
-     * @return the access token as a string
-     * @throws RuntimeException if the token retrieval fails or an I/O error occurs
-     */
-    public String accessToken(String clientId, String clientSecret) {
+
+    public String accessToken() {
         // Create the OkHttpClient instance
         OkHttpClient client = new OkHttpClient();
 
@@ -51,9 +51,7 @@ public class Authentication {
                 String responseBody = response.body().string();
                 ObjectMapper mapper = new ObjectMapper();
                 JsonNode jsonNode = mapper.readTree(responseBody);
-                String accessToken = jsonNode.get("access_token").asText();
-                //System.out.println("Access Token: " + accessToken);
-                return accessToken;
+                return jsonNode.get("access_token").asText();
             } else {
                 throw new RuntimeException("Failed to fetch access token. Response: " + response);
             }

--- a/java/src/main/java/org/opensky/model/OpenSkyStatesDeserializer.java
+++ b/java/src/main/java/org/opensky/model/OpenSkyStatesDeserializer.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 
 import java.io.IOException;
@@ -87,16 +88,19 @@ public class OpenSkyStatesDeserializer extends StdDeserializer<OpenSkyStates> {
 	@Override
 	public OpenSkyStates deserialize(JsonParser jp, DeserializationContext dc) throws IOException {
 		if (jp.getCurrentToken() != null && jp.getCurrentToken() != JsonToken.START_OBJECT) {
-			throw dc.mappingException(OpenSkyStates.class);
+			throw JsonMappingException.from(dc,
+					"Cannot map "
+							+ OpenSkyStates.class.getSimpleName()
+							+ ".Expected START_OBJECT but got " + jp.getCurrentToken());
 		}
 		try {
 			OpenSkyStates res = new OpenSkyStates();
 			for (jp.nextToken(); jp.getCurrentToken() != null && jp.getCurrentToken() != JsonToken.END_OBJECT; jp.nextToken()) {
 				if (jp.getCurrentToken() == JsonToken.FIELD_NAME) {
-					if ("time".equalsIgnoreCase(jp.getCurrentName())) {
+					if ("time".equalsIgnoreCase(jp.currentName())) {
 						int t = jp.nextIntValue(0);
 						res.setTime(t);
-					} else if ("states".equalsIgnoreCase(jp.getCurrentName())) {
+					} else if ("states".equalsIgnoreCase(jp.currentName())) {
 						jp.nextToken();
 						res.setStates(deserializeStates(jp));
 					} else {
@@ -107,7 +111,10 @@ public class OpenSkyStatesDeserializer extends StdDeserializer<OpenSkyStates> {
 			}
 			return res;
 		} catch (JsonParseException jpe) {
-			throw dc.mappingException(OpenSkyStates.class);
+			throw JsonMappingException.from(dc,
+					"Cannot map "
+							+ OpenSkyStates.class.getSimpleName()
+							+ ".Expected START_OBJECT but got " + jp.getCurrentToken());
 		}
 	}
 }

--- a/java/src/test/java/TestOpenSkyApi.java
+++ b/java/src/test/java/TestOpenSkyApi.java
@@ -1,10 +1,10 @@
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.opensky.api.OpenSkyApi;
 import org.opensky.model.OpenSkyStates;
 import org.opensky.model.StateVector;
 
 import java.io.IOException;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Markus Fuchs, fuchs@opensky-network.org
@@ -24,12 +24,12 @@ public class TestOpenSkyApi {
 		OpenSkyStates os = api.getStates(0, null);
 		long t1 = System.nanoTime();
 		System.out.println("Request anonStates time = " + ((t1 - t0) / 1000000) + "ms");
-		assertTrue("More than 1 state vector", os.getStates().size() > 1);
+		assertTrue(os.getStates().size() > 1, "More than 1 state vector");
 		int time = os.getTime();
 
 		// more than two requests withing ten seconds
 		os = api.getStates(0, null);
-		assertNull("No new data", os);
+		assertNull(os, "No new data");
 
 		// wait ten seconds
 		Thread.sleep(10000);
@@ -40,7 +40,7 @@ public class TestOpenSkyApi {
 		t1 = System.nanoTime();
 		System.out.println("Request anonStates time = " + ((t1 - t0) / 1000000) + "ms");
 		assertNotNull(os);
-		assertTrue("More than 1 state vector for second valid request", os.getStates().size() > 1);
+		assertTrue(os.getStates().size() > 1, "More than 1 state vector for second valid request");
 		assertNotEquals(time, os.getTime());
 
 		// test bounding box around Switzerland
@@ -75,7 +75,7 @@ public class TestOpenSkyApi {
 		}
 
 		OpenSkyStates os2 = api.getStates(0, null, new OpenSkyApi.BoundingBox(45.8389, 47.8229, 5.9962, 10.5226));
-		assertTrue("Much less states in Switzerland area than world-wide", os2.getStates().size() < os.getStates().size() - 200);
+		assertTrue(os2.getStates().size() < os.getStates().size() - 200, "Much less states in Switzerland area than world-wide");
 	}
 
 	// can only be tested with a valid account
@@ -88,12 +88,12 @@ public class TestOpenSkyApi {
 
 		OpenSkyApi api = new OpenSkyApi(USERNAME, PASSWORD);
 		OpenSkyStates os = api.getStates(0, null);
-		assertTrue("More than 1 state vector", os.getStates().size() > 1);
+		assertTrue(os.getStates().size() > 1, "More than 1 state vector");
 		int time = os.getTime();
 
 		// more than two requests withing ten seconds
 		os = api.getStates(0, null);
-		assertNull("No new data", os);
+		assertNull(os, "No new data");
 
 		// wait five seconds
 		Thread.sleep(5000);
@@ -104,7 +104,7 @@ public class TestOpenSkyApi {
 		long t1 = System.nanoTime();
 		System.out.println("Request authStates time = " + ((t1 - t0) / 1000000) + "ms");
 		assertNotNull(os);
-		assertTrue("More than 1 state vector for second valid request", os.getStates().size() > 1);
+		assertTrue(os.getStates().size() > 1, "More than 1 state vector for second valid request");
 		assertNotEquals(time, os.getTime());
 	}
 
@@ -116,8 +116,8 @@ public class TestOpenSkyApi {
 			fail("Anonymous access of 'myStates' expected");
 		} catch (IllegalAccessError iae) {
 			// like expected
-			assertTrue("Mismatched exception message",
-					iae.getMessage().equals("Anonymous access of 'myStates' not allowed"));
+			assertTrue(iae.getMessage().equals("Anonymous access of 'myStates' not allowed"),
+					"Mismatched exception message");
 		} catch (IOException e) {
 			fail("Request should not be submitted");
 		}
@@ -141,7 +141,7 @@ public class TestOpenSkyApi {
 
 		OpenSkyApi api = new OpenSkyApi(USERNAME, PASSWORD);
 		OpenSkyStates os = api.getMyStates(0, null, SERIALS);
-		assertTrue("More than 1 state vector", os.getStates().size() > 1);
+		assertTrue(os.getStates().size() > 1, "More than 1 state vector");
 
 		for (StateVector sv : os.getStates()) {
 			// all states contain at least one of the user's sensors

--- a/java/src/test/java/TestOpenSkyStatesDeserializer.java
+++ b/java/src/test/java/TestOpenSkyStatesDeserializer.java
@@ -1,7 +1,7 @@
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.opensky.model.OpenSkyStates;
 import org.opensky.model.OpenSkyStatesDeserializer;
 import org.opensky.model.StateVector;
@@ -9,7 +9,8 @@ import org.opensky.model.StateVector;
 import java.io.IOException;
 import java.util.Iterator;
 
-import static org.junit.Assert.*;
+import static java.lang.Double.valueOf;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Markus Fuchs, fuchs@opensky-network.org
@@ -33,17 +34,17 @@ public class TestOpenSkyStatesDeserializer {
 				"[null,\"ABCDEFG\",\"USA\",1001,1000,1.0,2.0,3.0,false,4.0,5.0,6.0,null]" +
 			"]}";
 
-	@Test(expected = JsonMappingException.class)
+	@Test()
 	public void testInvalidDeser() throws IOException {
 		ObjectMapper mapper = new ObjectMapper();
 		SimpleModule sm = new SimpleModule();
 		sm.addDeserializer(OpenSkyStates.class, new OpenSkyStatesDeserializer());
 		mapper.registerModule(sm);
 
-		mapper.readValue(invalidJson, OpenSkyStates.class);
+		assertThrows(JsonMappingException.class, () -> mapper.readValue(invalidJson, OpenSkyStates.class));
 	}
 
-	@Test(expected = JsonMappingException.class)
+	@Test
 	public void testInvalidDeser2() throws IOException {
 		ObjectMapper mapper = new ObjectMapper();
 		SimpleModule sm = new SimpleModule();
@@ -51,7 +52,7 @@ public class TestOpenSkyStatesDeserializer {
 		mapper.registerModule(sm);
 
 		// ObjectMapper throws Exception here
-		mapper.readValue("", OpenSkyStates.class);
+		assertThrows(JsonMappingException.class, () -> mapper.readValue("", OpenSkyStates.class));
 	}
 
 	@Test
@@ -77,8 +78,8 @@ public class TestOpenSkyStatesDeserializer {
 		mapper.registerModule(sm);
 
 		OpenSkyStates states = mapper.readValue(validJson, OpenSkyStates.class);
-		assertEquals("Correct Time", 1002, states.getTime());
-		assertEquals("Number states", 6, states.getStates().size());
+		assertEquals(1002, states.getTime(), "Correct Time");
+		assertEquals(6, states.getStates().size(), "Number states");
 
 		// possible cases for state vectors
 		Iterator<StateVector> statesIt = states.getStates().iterator();
@@ -88,17 +89,17 @@ public class TestOpenSkyStatesDeserializer {
 		assertEquals( "cabeef", sv.getIcao24());
 		assertEquals("ABCDEFG", sv.getCallsign());
 		assertEquals("USA", sv.getOriginCountry());
-		assertEquals(new Double(1001), sv.getLastPositionUpdate());
-		assertEquals(new Double(1000), sv.getLastContact());
-		assertEquals(new Double(1.0), sv.getLongitude());
-		assertEquals(new Double(2.0), sv.getLatitude());
-		assertEquals(new Double(3.0), sv.getBaroAltitude());
-		assertEquals(new Double(4.0), sv.getVelocity());
-		assertEquals(new Double(5.0), sv.getHeading());
-		assertEquals(new Double(6.0), sv.getVerticalRate());
+		assertEquals(valueOf(1001), sv.getLastPositionUpdate());
+		assertEquals(valueOf(1000), sv.getLastContact());
+		assertEquals(valueOf(1.0), sv.getLongitude());
+		assertEquals(valueOf(2.0), sv.getLatitude());
+		assertEquals(valueOf(3.0), sv.getBaroAltitude());
+		assertEquals(valueOf(4.0), sv.getVelocity());
+		assertEquals(valueOf(5.0), sv.getHeading());
+		assertEquals(valueOf(6.0), sv.getVerticalRate());
 		assertFalse(sv.isOnGround());
 		assertNull(sv.getSerials());
-		assertEquals(new Double(6743.7), sv.getGeoAltitude());
+		assertEquals(valueOf(6743.7), sv.getGeoAltitude());
 		assertEquals("6714", sv.getSquawk());
 		assertFalse(sv.isSpi());
 		assertEquals(StateVector.PositionSource.ADS_B, sv.getPositionSource());
@@ -109,13 +110,13 @@ public class TestOpenSkyStatesDeserializer {
 		assertNull(sv.getCallsign());
 		assertEquals("USA", sv.getOriginCountry());
 		assertNull(sv.getLastPositionUpdate());
-		assertEquals(new Double(1000), sv.getLastContact());
+		assertEquals(valueOf(1000), sv.getLastContact());
 		assertNull(sv.getLongitude());
 		assertNull(sv.getLatitude());
 		assertNull(sv.getGeoAltitude());
-		assertEquals(new Double(4.0), sv.getVelocity());
-		assertEquals(new Double(5.0), sv.getHeading());
-		assertEquals(new Double(6.0), sv.getVerticalRate());
+		assertEquals(valueOf(4.0), sv.getVelocity());
+		assertEquals(valueOf(5.0), sv.getHeading());
+		assertEquals(valueOf(6.0), sv.getVerticalRate());
 		assertFalse(sv.isOnGround());
 		assertNull(sv.getSerials());
 		assertNull(sv.getBaroAltitude());
@@ -128,17 +129,17 @@ public class TestOpenSkyStatesDeserializer {
 		assertEquals( "cabeef", sv.getIcao24());
 		assertNull(sv.getCallsign());
 		assertEquals("USA", sv.getOriginCountry());
-		assertEquals(new Double(1001), sv.getLastPositionUpdate());
+		assertEquals(valueOf(1001), sv.getLastPositionUpdate());
 		assertNull(sv.getLastContact());
-		assertEquals(new Double(1.0), sv.getLongitude());
-		assertEquals(new Double(2.0), sv.getLatitude());
-		assertEquals(new Double(3.0), sv.getBaroAltitude());
+		assertEquals(valueOf(1.0), sv.getLongitude());
+		assertEquals(valueOf(2.0), sv.getLatitude());
+		assertEquals(valueOf(3.0), sv.getBaroAltitude());
 		assertNull(sv.getVelocity());
 		assertNull(sv.getHeading());
 		assertNull(sv.getVerticalRate());
 		assertFalse(sv.isOnGround());
 		assertNull(sv.getSerials());
-		assertEquals(new Double(6743.7), sv.getGeoAltitude());
+		assertEquals(valueOf(6743.7), sv.getGeoAltitude());
 		assertNull(sv.getSquawk());
 		assertFalse(sv.isSpi());
 		assertEquals(StateVector.PositionSource.ADS_B, sv.getPositionSource());
@@ -148,17 +149,17 @@ public class TestOpenSkyStatesDeserializer {
 		assertEquals( "cabeef", sv.getIcao24());
 		assertEquals("ABCDEFG", sv.getCallsign());
 		assertEquals("USA", sv.getOriginCountry());
-		assertEquals(new Double(1001), sv.getLastPositionUpdate());
-		assertEquals(new Double(1000), sv.getLastContact());
-		assertEquals(new Double(1.0), sv.getLongitude());
-		assertEquals(new Double(2.0), sv.getLatitude());
-		assertEquals(new Double(3.0), sv.getBaroAltitude());
-		assertEquals(new Double(4.0), sv.getVelocity());
-		assertEquals(new Double(5.0), sv.getHeading());
-		assertEquals(new Double(6.0), sv.getVerticalRate());
+		assertEquals(valueOf(1001), sv.getLastPositionUpdate());
+		assertEquals(valueOf(1000), sv.getLastContact());
+		assertEquals(valueOf(1.0), sv.getLongitude());
+		assertEquals(valueOf(2.0), sv.getLatitude());
+		assertEquals(valueOf(3.0), sv.getBaroAltitude());
+		assertEquals(valueOf(4.0), sv.getVelocity());
+		assertEquals(valueOf(5.0), sv.getHeading());
+		assertEquals(valueOf(6.0), sv.getVerticalRate());
 		assertFalse(sv.isOnGround());
 		assertArrayEquals(new Integer[] {1234, 6543}, sv.getSerials().toArray(new Integer[sv.getSerials().size()]));
-		assertEquals(new Double(6743.7), sv.getGeoAltitude());
+		assertEquals(valueOf(6743.7), sv.getGeoAltitude());
 		assertEquals("6714", sv.getSquawk());
 		assertFalse(sv.isSpi());
 		assertEquals(StateVector.PositionSource.ASTERIX, sv.getPositionSource());
@@ -168,17 +169,17 @@ public class TestOpenSkyStatesDeserializer {
 		assertEquals( "cabeef", sv.getIcao24());
 		assertEquals("ABCDEFG", sv.getCallsign());
 		assertEquals("USA", sv.getOriginCountry());
-		assertEquals(new Double(1001), sv.getLastPositionUpdate());
-		assertEquals(new Double(1000), sv.getLastContact());
-		assertEquals(new Double(1.0), sv.getLongitude());
-		assertEquals(new Double(2.0), sv.getLatitude());
-		assertEquals(new Double(3.0), sv.getBaroAltitude());
-		assertEquals(new Double(4.0), sv.getVelocity());
-		assertEquals(new Double(5.0), sv.getHeading());
-		assertEquals(new Double(6.0), sv.getVerticalRate());
+		assertEquals(valueOf(1001), sv.getLastPositionUpdate());
+		assertEquals(valueOf(1000), sv.getLastContact());
+		assertEquals(valueOf(1.0), sv.getLongitude());
+		assertEquals(valueOf(2.0), sv.getLatitude());
+		assertEquals(valueOf(3.0), sv.getBaroAltitude());
+		assertEquals(valueOf(4.0), sv.getVelocity());
+		assertEquals(valueOf(5.0), sv.getHeading());
+		assertEquals(valueOf(6.0), sv.getVerticalRate());
 		assertFalse(sv.isOnGround());
 		assertArrayEquals(new Integer[] {1234}, sv.getSerials().toArray(new Integer[sv.getSerials().size()]));
-		assertEquals(new Double(6743.7), sv.getGeoAltitude());
+		assertEquals(valueOf(6743.7), sv.getGeoAltitude());
 		assertEquals("6714", sv.getSquawk());
 		assertTrue(sv.isSpi());
 		assertEquals(StateVector.PositionSource.UNKNOWN, sv.getPositionSource());
@@ -189,14 +190,14 @@ public class TestOpenSkyStatesDeserializer {
 		assertEquals( "cabeef", sv.getIcao24());
 		assertEquals("ABCDEFG", sv.getCallsign());
 		assertEquals("USA", sv.getOriginCountry());
-		assertEquals(new Double(1001), sv.getLastPositionUpdate());
-		assertEquals(new Double(1000), sv.getLastContact());
-		assertEquals(new Double(1.0), sv.getLongitude());
-		assertEquals(new Double(2.0), sv.getLatitude());
-		assertEquals(new Double(3.0), sv.getBaroAltitude());
-		assertEquals(new Double(4.0), sv.getVelocity());
-		assertEquals(new Double(5.0), sv.getHeading());
-		assertEquals(new Double(6.0), sv.getVerticalRate());
+		assertEquals(valueOf(1001), sv.getLastPositionUpdate());
+		assertEquals(valueOf(1000), sv.getLastContact());
+		assertEquals(valueOf(1.0), sv.getLongitude());
+		assertEquals(valueOf(2.0), sv.getLatitude());
+		assertEquals(valueOf(3.0), sv.getBaroAltitude());
+		assertEquals(valueOf(4.0), sv.getVelocity());
+		assertEquals(valueOf(5.0), sv.getHeading());
+		assertEquals(valueOf(6.0), sv.getVerticalRate());
 		assertTrue(sv.isOnGround());
 		assertNull(sv.getSerials());
 		assertNull(sv.getGeoAltitude());


### PR DESCRIPTION
Added support for OAuth2 Client Credentials Flow.  See new OpenSkyAuthentication.java. Adds a new constructor to OpenSkyApi:

```
OpenSkyApi api = new OpenSkyApi(new OpenSkyAuthentication("clientId", "clientSecret"));
    OpenSkyStates os = api.getStates(0, null,
            new OpenSkyApi.BoundingBox(45.8389, 47.8229, 5.9962, 10.5226));

    os.getStates().forEach(System.out::println);
```

Additional changes:

- Upgraded all build dependencies 
- Upgraded tests to JUnit Jupiter
- Updated deprecated method dc.mappingException(...) to JsonMappingExpception
- Bumps the Java release version to 17
- Bumps the library version to 1.4.0
